### PR TITLE
Ported firesensor from old KS code, tested and functional.

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
@@ -1,3 +1,17 @@
+// SPDX-FileCopyrightText: 2022 Paul Ritter
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2023 Chief-Engineer
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2024 Jezithyr
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 Mervill
+// SPDX-FileCopyrightText: 2024 drakewill-CRL
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+// SPDX-FileCopyrightText: 2025 metalgearsloth
+// SPDX-FileCopyrightText: 2025 nabegator220
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.Reactions;
 using Content.Shared.Atmos;

--- a/Content.Server/Atmos/Monitor/Components/AtmosMonitorComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AtmosMonitorComponent.cs
@@ -1,3 +1,17 @@
+// SPDX-FileCopyrightText: 2022 Flipp Syder
+// SPDX-FileCopyrightText: 2022 Paul Ritter
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2022 mirrorcult
+// SPDX-FileCopyrightText: 2022 vulppine
+// SPDX-FileCopyrightText: 2022 wrexbe
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 chromiumboy
+// SPDX-FileCopyrightText: 2025 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2025 nabegator220
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Monitor;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -1,3 +1,24 @@
+// SPDX-FileCopyrightText: 2022 Flipp Syder
+// SPDX-FileCopyrightText: 2022 Paul Ritter
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2022 keronshb
+// SPDX-FileCopyrightText: 2022 mirrorcult
+// SPDX-FileCopyrightText: 2022 vulppine
+// SPDX-FileCopyrightText: 2022 wrexbe
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Kara
+// SPDX-FileCopyrightText: 2023 Menshin
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 chromiumboy
+// SPDX-FileCopyrightText: 2024 osjarw
+// SPDX-FileCopyrightText: 2025 Palladinium
+// SPDX-FileCopyrightText: 2025 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2025 Southbridge
+// SPDX-FileCopyrightText: 2025 metalgearsloth
+// SPDX-FileCopyrightText: 2025 nabegator220
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Monitor.Components;
 using Content.Server.Atmos.Piping.Components;

--- a/Content.Server/Atmos/TileExtinguishEvent.cs
+++ b/Content.Server/Atmos/TileExtinguishEvent.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+// SPDX-FileCopyrightText: 2025 nabegator220
+//
+// SPDX-License-Identifier: MPL-2.0
+
 namespace Content.Server.Atmos;
 
 /// <summary>

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
@@ -1,3 +1,34 @@
+# SPDX-FileCopyrightText: 2022 Andreas Kämper
+# SPDX-FileCopyrightText: 2022 Emisse
+# SPDX-FileCopyrightText: 2022 Flipp Syder
+# SPDX-FileCopyrightText: 2022 Fooberticus Bazly
+# SPDX-FileCopyrightText: 2022 Jacob Tong
+# SPDX-FileCopyrightText: 2022 Julian Giebel
+# SPDX-FileCopyrightText: 2022 Mervill
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2022 fooberticus
+# SPDX-FileCopyrightText: 2022 vulppine
+# SPDX-FileCopyrightText: 2023 DrSmugleaf
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Morb
+# SPDX-FileCopyrightText: 2023 qwerltaz
+# SPDX-FileCopyrightText: 2024 Ilya246
+# SPDX-FileCopyrightText: 2024 Kara
+# SPDX-FileCopyrightText: 2024 ScarKy0
+# SPDX-FileCopyrightText: 2024 chromiumboy
+# SPDX-FileCopyrightText: 2024 deltanedas
+# SPDX-FileCopyrightText: 2024 metalgearsloth
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba
+# SPDX-FileCopyrightText: 2025 Kyle Tyo
+# SPDX-FileCopyrightText: 2025 SlamBamActionman
+# SPDX-FileCopyrightText: 2025 kosticia
+# SPDX-FileCopyrightText: 2025 lzk
+# SPDX-FileCopyrightText: 2025 nabegator220
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entity
   parent: BaseWallmountMachine
   id: AirAlarm

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/fire_alarm.yml
@@ -1,3 +1,27 @@
+# SPDX-FileCopyrightText: 2022 Andreas Kämper
+# SPDX-FileCopyrightText: 2022 Flipp Syder
+# SPDX-FileCopyrightText: 2022 Julian Giebel
+# SPDX-FileCopyrightText: 2022 Mervill
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2022 vulppine
+# SPDX-FileCopyrightText: 2023 DrSmugleaf
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Morb
+# SPDX-FileCopyrightText: 2024 Ilya246
+# SPDX-FileCopyrightText: 2024 Kara
+# SPDX-FileCopyrightText: 2024 chromiumboy
+# SPDX-FileCopyrightText: 2024 metalgearsloth
+# SPDX-FileCopyrightText: 2024 qwerltaz
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba
+# SPDX-FileCopyrightText: 2025 SlamBamActionman
+# SPDX-FileCopyrightText: 2025 kosticia
+# SPDX-FileCopyrightText: 2025 lzk
+# SPDX-FileCopyrightText: 2025 nabegator220
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entity
   parent: BaseWallmountMachine
   id: FireAlarm

--- a/Resources/Prototypes/_KS14/Entities/Objects/Devices/Electronics/firesensor.yml
+++ b/Resources/Prototypes/_KS14/Entities/Objects/Devices/Electronics/firesensor.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 nabegator220
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entity
   id: FireSensor
   parent: AirSensorBase

--- a/Resources/Prototypes/_KS14/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/_KS14/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 nabegator220
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entity
   parent: BaseItem
   id: FireSensorAssembly

--- a/Resources/Prototypes/_KS14/Recipes/Construction/Graphs/Utilities/fire_sensor.yml
+++ b/Resources/Prototypes/_KS14/Recipes/Construction/Graphs/Utilities/fire_sensor.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 vulppine
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2025 nabegator220
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: constructionGraph
   id: FireSensor
   start: start

--- a/Resources/Prototypes/_KS14/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/_KS14/Recipes/Construction/utilities.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 nabegator220
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: construction
   name: fire sensor
   id: FireSensor

--- a/Resources/Prototypes/_KS14/Tags/tags.yml
+++ b/Resources/Prototypes/_KS14/Tags/tags.yml
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2025 nabegator220
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: Tag
   id: FireSensor # Ganimed - KS14 fire sensor port


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- READ THIS BEFORE CONTRIBUTING TO KS14!!!
NOTE: You must not port AGPL content that is utilised by any other MIT/MPL/otherwise non-AGPL licensed content. This is due to the viral nature
of AGPL, where any code that uses AGPL must itself be licensed under AGPL. You are heavily discouraged from having code licensed under the AGPL in your PR.

The REUSE Specification headers or separate .license files indicate a secondary license (e.g., AGPL or MIT), solely to facilitate
integration for projects that do not fall under a single license.

REUSE headers will be automatically added via github workflow. You can edit the SPDX-License-Identifier to change the license that the file is specified as having.
SPDX license identifiers already included in files relevant to the PR, or identifiers that were manually changed after being automatically added, will not be modified by the bot.

For clarity: You are recommended to have PR-relevant upstream-original (wizard's den) files be licensed as MIT. KS14 uses the MPL license for content original to KS14.
This individual comment block can be safely removed, but you must preserve the below comment block specifying the default license of this PR.

Uncomment and modify the following line if you wish to change the auto-added license from the default of MPL. Set to `AGPL` for AGPL-3.0-or-later, `MPL` for MPL-2.0, and `MIT` for MIT.
-->
<!--- LICENSE: MPL -->
## About the PR
Added the fire alarm, a KS feature designed to help beginner atmosians.

## Why
Atmos is already hard enough.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] Any AGPL code (if present) included in this PR is *not* used by other non-AGPL code.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the fire sensor, a special sensor that trips when its tile is on fire.
