### PR TITLE
Agplisation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,21 +15,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
 
 <!-- READ THIS BEFORE CONTRIBUTING TO KS14!!!
-NOTE: You must not port AGPL content that is utilised by any other MIT/MPL/otherwise non-AGPL licensed content. This is due to the viral nature
-of AGPL, where any code that uses AGPL must itself be licensed under AGPL. You are heavily discouraged from having code licensed under the AGPL in your PR.
-
 The REUSE Specification headers or separate .license files indicate a secondary license (e.g., AGPL or MIT), solely to facilitate
 integration for projects that do not fall under a single license.
 
 REUSE headers will be automatically added via github workflow. You can edit the SPDX-License-Identifier to change the license that the file is specified as having.
 SPDX license identifiers already included in files relevant to the PR, or identifiers that were manually changed after being automatically added, will not be modified by the bot.
 
-For clarity: You are recommended to have PR-relevant upstream-original (wizard's den) files be licensed as MIT. KS14 uses the MPL license for content original to KS14.
+For clarity: You are recommended to have PR-relevant upstream-original (wizard's den) files be licensed as MIT. KS14 uses the AGPL license for content original to KS14.
 This individual comment block can be safely removed, but you must preserve the below comment block specifying the default license of this PR.
 
 Uncomment and modify the following line if you wish to change the auto-added license from the default of MPL. Set to `AGPL` for AGPL-3.0-or-later, `MPL` for MPL-2.0, and `MIT` for MIT.
 -->
-<!--- LICENSE: MPL -->
+<!--- LICENSE: AGPL -->
 ## About the PR
 <!-- What did you change? -->
 
@@ -43,7 +40,6 @@ Uncomment and modify the following line if you wish to change the auto-added lic
 <!-- Confirm the following by placing an X in the brackets [X]: -->
 - [ ] Tested, works.
 - [ ] I have added media to this PR or it does not require an ingame showcase.
-- [ ] Any AGPL code (if present) included in this PR is *not* used by other non-AGPL code.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
 
 ## Breaking changes

--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@ The [Wizard's Den docs site](https://docs.spacestation14.com/) has documentation
 
 ## Legal Info
 
+All code in this codebase is released under the AGPL-3.0-or-later license. Each file includes REUSE Specification headers or separate .license files that specify a dual license option. This dual licensing is provided to simplify the process for projects that are not using AGPL, allowing them to adopt the relevant portions of the code under an alternative license. You can review the complete texts of these licenses in the LICENSES/ directory.
+
 Source files in this repository are licensed under one of the three below licenses:
 - [MIT](https://github.com/Space-Klovns/Klovnstation14/blob/master/LICENSES/MIT.txt)
 - [MPL-2.0](https://github.com/Space-Klovns/Klovnstation14/blob/master/LICENSES/MPL-2.0.txt)
 - [AGPL-3.0-or-later](https://github.com/Space-Klovns/Klovnstation14/blob/master/LICENSES/AGPL-3.0-or-later.txt)
 
 All code past commit hash f9a52e8fbb8066e56d34ba1908c399699e801c42 on Wed, 29 Oct 2025 16:04:39 +0000 is also automatically subject to [this notice](NOTICE).
-
-Each source file in this repository may include a REUSE specification header, specifying its license and copyright holder(s).
-Files with no license headers are licensed under the [MIT license](https://github.com/Space-Klovns/Klovnstation14/blob/master/LICENSES/MIT.txt) by default.
-The full texts of these licenses are provided under the LICENSES/ directory.
+Inclusion of additional legal notices is allowed under §7(b) of the (A)GPL assuming they do not infringe on any of the freedoms granted to the user by the license.
 
 Most media assets are licensed under [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) unless stated otherwise. Assets have their license and the copyright in the metadata file. [Example](https://github.com/space-wizards/space-station-14/blob/master/Resources/Textures/Objects/Tools/crowbar.rsi/meta.json).
 

--- a/Tools/reuse/apply_reuse_headers.py
+++ b/Tools/reuse/apply_reuse_headers.py
@@ -17,7 +17,7 @@ import time
 # --- Configuration ---
 CUTOFF_COMMIT_HASH = "5f56751555bd2851e4656efdb09554fa4849edd7"
 LICENSE_BEFORE = "MIT"
-LICENSE_AFTER = "MPL-2.0"
+LICENSE_AFTER = "AGPL-3.0-or-later"
 FILE_PATTERNS = ["*.cs", "*.js", "*.ts", "*.jsx", "*.tsx", "*.c", "*.cpp", "*.cc", "*.h", "*.hpp",
                 "*.java", "*.scala", "*.kt", "*.swift", "*.go", "*.rs", "*.dart", "*.groovy", "*.php",
                 "*.yaml", "*.yml", "*.ftl", "*.py", "*.rb", "*.pl", "*.pm", "*.sh", "*.bash", "*.zsh",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- READ THIS BEFORE CONTRIBUTING TO KS14!!!
NOTE: You must not port AGPL content that is utilised by any other MIT/MPL/otherwise non-AGPL licensed content. This is due to the viral nature
of AGPL, where any code that uses AGPL must itself be licensed under AGPL. You are heavily discouraged from having code licensed under the AGPL in your PR.

The REUSE Specification headers or separate .license files indicate a secondary license (e.g., AGPL or MIT), solely to facilitate
integration for projects that do not fall under a single license.

REUSE headers will be automatically added via github workflow. You can edit the SPDX-License-Identifier to change the license that the file is specified as having.
SPDX license identifiers already included in files relevant to the PR, or identifiers that were manually changed after being automatically added, will not be modified by the bot.

For clarity: You are recommended to have PR-relevant upstream-original (wizard's den) files be licensed as MIT. KS14 uses the MPL license for content original to KS14.
This individual comment block can be safely removed, but you must preserve the below comment block specifying the default license of this PR.

Uncomment and modify the following line if you wish to change the auto-added license from the default of MPL. Set to `AGPL` for AGPL-3.0-or-later, `MPL` for MPL-2.0, and `MIT` for MIT.
-->
<!--- LICENSE: AGPL -->
## About the PR
Agplised the repo

## Why
It had to come someday. There aren't enough of us to bypass content drought without porting or reusing others' code.

