### PR TITLE
klovn maints spawner tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -1,3 +1,55 @@
+# SPDX-FileCopyrightText: 2022 Chris V
+# SPDX-FileCopyrightText: 2022 Kara
+# SPDX-FileCopyrightText: 2022 Moony
+# SPDX-FileCopyrightText: 2022 Pancake
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 ZeroDayDaemon
+# SPDX-FileCopyrightText: 2023 Danger Revolution!
+# SPDX-FileCopyrightText: 2023 DangerRevoltion
+# SPDX-FileCopyrightText: 2023 Ed
+# SPDX-FileCopyrightText: 2023 Nairod
+# SPDX-FileCopyrightText: 2023 Nim
+# SPDX-FileCopyrightText: 2023 PixelTK
+# SPDX-FileCopyrightText: 2023 Puro
+# SPDX-FileCopyrightText: 2023 Topy
+# SPDX-FileCopyrightText: 2023 Vordenburg
+# SPDX-FileCopyrightText: 2023 c4llv07e
+# SPDX-FileCopyrightText: 2023 faint
+# SPDX-FileCopyrightText: 2023 forthbridge
+# SPDX-FileCopyrightText: 2023 ninruB
+# SPDX-FileCopyrightText: 2023 nmajask
+# SPDX-FileCopyrightText: 2024 2013HORSEMEATSCANDAL
+# SPDX-FileCopyrightText: 2024 ArtisticRoomba
+# SPDX-FileCopyrightText: 2024 Flareguy
+# SPDX-FileCopyrightText: 2024 Ilya246
+# SPDX-FileCopyrightText: 2024 MACMAN2003
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 TakoDragon
+# SPDX-FileCopyrightText: 2024 Terraspark4941
+# SPDX-FileCopyrightText: 2024 Ubaser
+# SPDX-FileCopyrightText: 2024 brainfood1183
+# SPDX-FileCopyrightText: 2024 metalgearsloth
+# SPDX-FileCopyrightText: 2024 themias
+# SPDX-FileCopyrightText: 2024 xprospero
+# SPDX-FileCopyrightText: 2025 AsnDen
+# SPDX-FileCopyrightText: 2025 Boaz1111
+# SPDX-FileCopyrightText: 2025 Cass
+# SPDX-FileCopyrightText: 2025 DeusMaldPr
+# SPDX-FileCopyrightText: 2025 IProduceWidgets
+# SPDX-FileCopyrightText: 2025 Julian Giebel
+# SPDX-FileCopyrightText: 2025 Momo
+# SPDX-FileCopyrightText: 2025 Smugman
+# SPDX-FileCopyrightText: 2025 Southbridge
+# SPDX-FileCopyrightText: 2025 T
+# SPDX-FileCopyrightText: 2025 Unkn0wn_Gh0st
+# SPDX-FileCopyrightText: 2025 centcomofficer24
+# SPDX-FileCopyrightText: 2025 lzk
+# SPDX-FileCopyrightText: 2025 slarticodefast
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entityTable
   id: MaintFluffTable
   table: !type:GroupSelector

--- a/Resources/Prototypes/_KS14/Entities/Markers/Spawners/Random/maintence.yml
+++ b/Resources/Prototypes/_KS14/Entities/Markers/Spawners/Random/maintence.yml
@@ -1,4 +1,8 @@
-﻿#try keeping weights at 100/100 for ease of tweaking (Ideally)
+# SPDX-FileCopyrightText: 2025 DeusMaldPr
+#
+# SPDX-License-Identifier: MPL-2.0
+
+#try keeping weights at 100/100 for ease of tweaking (Ideally)
 #also sort by weight
 
 - type: entityTable

--- a/Resources/Prototypes/_KS14/Entities/Objects/Decoration/present.yml
+++ b/Resources/Prototypes/_KS14/Entities/Objects/Decoration/present.yml
@@ -1,4 +1,8 @@
-﻿- type: entity
+# SPDX-FileCopyrightText: 2025 DeusMaldPr
+#
+# SPDX-License-Identifier: MPL-2.0
+
+- type: entity
   id: PresentGibstick
   parent: [PresentBase, BaseItem]
   suffix: Filled God Fearing


### PR DESCRIPTION
## About the PR
added pistol barrel to maint locker
changed how often weapons maint spawn 
added maints ammo spawner
unused gibstick present

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Put pistol barrels in maints lockers (gg)
- add: Maints weapons should spawn more now
- add: (For mappers) Maints ammo spawner, expect to find a loose shell or pistol mag in a few places.
