### PR TITLE
enable dwarves as roundstart specie

### DIFF
--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Errant
 # SPDX-FileCopyrightText: 2025 DeusMaldPr
+# SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+# SPDX-FileCopyrightText: 2025 LuciferEOS
 # SPDX-FileCopyrightText: 2025 ScarKy0
 #
 # SPDX-License-Identifier: MIT

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2022 Flipp Syder
 # SPDX-FileCopyrightText: 2023 Emisse
 # SPDX-FileCopyrightText: 2025 DeusMaldPr
+# SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+# SPDX-FileCopyrightText: 2025 LuciferEOS
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
drarves are humans but raiders, see no reason why not
- [x] i did not test this shit
:cl: LuciferEOS
- tweak: Beer people lovers are now available roundstart