### PR TITLE
Watchdog update workflow

### DIFF
--- a/.github/workflows/server-update-workflow.yml
+++ b/.github/workflows/server-update-workflow.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+#
+# SPDX-License-Identifier: MPL-2.0
 
 # Every once in a while, this POSTs the KS14 watchdog server to ask it to update with latest repo master.
 


### PR DESCRIPTION
LICENSE: MPL

Added new workflow that runs every day at 18:00 UTC, which pings the gameserver's watchdog to make it update the server (if any updates were made)

It can also be manually triggered