### PR TITLE
port prioritize borg UI over stripping UI 

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -1,3 +1,20 @@
+// SPDX-FileCopyrightText: 2024 DrSmugleaf
+// SPDX-FileCopyrightText: 2024 Krunklehorn
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 ShadowCommander
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2024 to4no_fix
+// SPDX-FileCopyrightText: 2025 Gerkada
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+// SPDX-FileCopyrightText: 2025 Nemanja
+// SPDX-FileCopyrightText: 2025 SlamBamActionman
+// SPDX-FileCopyrightText: 2025 Tayrtahn
+// SPDX-FileCopyrightText: 2025 lzk
+// SPDX-FileCopyrightText: 2025 nabegator220
+//
+// SPDX-License-Identifier: MIT
+
 using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CombatMode;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- READ THIS BEFORE CONTRIBUTING TO KS14!!!
The REUSE Specification headers or separate .license files indicate a secondary license (if any, but e.g., the MPL or MIT licenses) alongside the AGPL, solely to facilitate
integration for projects that do not fall under a single license.

REUSE headers will be automatically added via github workflow. You can edit the SPDX-License-Identifier to change the license that the file is specified as having.
SPDX license identifiers already included in files relevant to the PR, or identifiers that were manually changed after being automatically added, will not be modified by the bot.

For clarity: You are recommended to have PR-relevant upstream-original (wizden's) files be licensed as MIT. KS14 uses the MPL license for content original to KS14.
This individual comment block can be safely removed, but you must preserve the below comment block specifying the default license of this PR.

Uncomment and modify the following line if you wish to change the auto-added license from the default of MPL. Set to `AGPL` for AGPL-3.0-or-later, `MPL` for MPL-2.0, and `MIT` for MIT.
-->
LICENSE: MIT
## About the PR
<!-- What did you change? -->
Prioritizes the borg UI over the stripping UI when pressing E on a borg.
If the borg is locked or has a closed wire panel and the borg UI cannot be opened then it will open the stripping UI instead.
The stripping UI is always available via drag drop.

## Why
<!-- Explain why this was changed. -->
QoL o algo 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->
No

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
4 lines of code lmfao

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Gerkada
- add: Pressing E on unlocked borgs with an open wire panel will now open the borg UI instead of the stripping UI.

