### PR TITLE
Common medical chem changes 

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -47,10 +47,11 @@
 # SPDX-FileCopyrightText: 2025 chromiumboy
 # SPDX-FileCopyrightText: 2025 godisdeadLOL
 # SPDX-FileCopyrightText: 2025 lzk
-# SPDX-FileCopyrightText: 2025 nabegator220
 # SPDX-FileCopyrightText: 2025 slarticodefast
+# SPDX-FileCopyrightText: 2026 DeusMaldPr
 # SPDX-FileCopyrightText: 2026 Gerkada
 # SPDX-FileCopyrightText: 2026 github_actions[bot]
+# SPDX-FileCopyrightText: 2026 nabegator220
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -392,7 +392,7 @@
         reagent: Tricordrazine
         quantity: 30
         minDamage: 0
-        maxDamage: 50
+        maxDamage: 100 #klovn,Real trico
       Critical:
         reagent: Inaprovaline
         quantity: 15

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1,3 +1,83 @@
+# SPDX-FileCopyrightText: 2019 moneyl
+# SPDX-FileCopyrightText: 2020 AJCM-git
+# SPDX-FileCopyrightText: 2020 Hugo Laloge
+# SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto
+# SPDX-FileCopyrightText: 2020 nuke
+# SPDX-FileCopyrightText: 2021 DmitriyRubetskoy
+# SPDX-FileCopyrightText: 2021 Elijahrane
+# SPDX-FileCopyrightText: 2021 SETh lafuente
+# SPDX-FileCopyrightText: 2021 ScalyChimp
+# SPDX-FileCopyrightText: 2021 SethLafuente
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2021 xRiriq
+# SPDX-FileCopyrightText: 2022 CrudeWax
+# SPDX-FileCopyrightText: 2022 EmoGarbage404
+# SPDX-FileCopyrightText: 2022 Flipp Syder
+# SPDX-FileCopyrightText: 2022 Jack Fox
+# SPDX-FileCopyrightText: 2022 Julian Giebel
+# SPDX-FileCopyrightText: 2022 Kara
+# SPDX-FileCopyrightText: 2022 Kara D
+# SPDX-FileCopyrightText: 2022 Leon Friedrich
+# SPDX-FileCopyrightText: 2022 Moony
+# SPDX-FileCopyrightText: 2022 Myctai
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 Ripmorld
+# SPDX-FileCopyrightText: 2022 Sam Weaver
+# SPDX-FileCopyrightText: 2022 ShadowCommander
+# SPDX-FileCopyrightText: 2022 lapatison
+# SPDX-FileCopyrightText: 2022 mirrorcult
+# SPDX-FileCopyrightText: 2023 Alekshhh
+# SPDX-FileCopyrightText: 2023 Alex Evgrashin
+# SPDX-FileCopyrightText: 2023 CrigCrag
+# SPDX-FileCopyrightText: 2023 DjfjdfofdjfjD
+# SPDX-FileCopyrightText: 2023 Doru991
+# SPDX-FileCopyrightText: 2023 Dynexust
+# SPDX-FileCopyrightText: 2023 Emisse
+# SPDX-FileCopyrightText: 2023 IProduceWidgets
+# SPDX-FileCopyrightText: 2023 Interrobang01
+# SPDX-FileCopyrightText: 2023 Kevin Zheng
+# SPDX-FileCopyrightText: 2023 LankLTE
+# SPDX-FileCopyrightText: 2023 Maxtone
+# SPDX-FileCopyrightText: 2023 Sir Winters
+# SPDX-FileCopyrightText: 2023 Veritius
+# SPDX-FileCopyrightText: 2023 Visne
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2023 nikthechampiongr
+# SPDX-FileCopyrightText: 2024 EdenTheLiznerd
+# SPDX-FileCopyrightText: 2024 Ghagliiarghii
+# SPDX-FileCopyrightText: 2024 Gotimanga
+# SPDX-FileCopyrightText: 2024 Scribbles0
+# SPDX-FileCopyrightText: 2024 Skye
+# SPDX-FileCopyrightText: 2024 Tayrtahn
+# SPDX-FileCopyrightText: 2024 Ubaser
+# SPDX-FileCopyrightText: 2024 deltanedas
+# SPDX-FileCopyrightText: 2024 icekot8
+# SPDX-FileCopyrightText: 2024 potato1234_x
+# SPDX-FileCopyrightText: 2024 slarticodefast
+# SPDX-FileCopyrightText: 2024 themias
+# SPDX-FileCopyrightText: 2025 Admiral-Obvious-001
+# SPDX-FileCopyrightText: 2025 Alzore
+# SPDX-FileCopyrightText: 2025 Errant
+# SPDX-FileCopyrightText: 2025 FrostRibbon
+# SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+# SPDX-FileCopyrightText: 2025 Nemanja
+# SPDX-FileCopyrightText: 2025 OnyxTheBrave
+# SPDX-FileCopyrightText: 2025 PJB3005
+# SPDX-FileCopyrightText: 2025 Red
+# SPDX-FileCopyrightText: 2025 Samuka-C
+# SPDX-FileCopyrightText: 2025 ScarKy0
+# SPDX-FileCopyrightText: 2025 SlamBamActionman
+# SPDX-FileCopyrightText: 2025 Vasilis The Pikachu
+# SPDX-FileCopyrightText: 2025 emberwinters
+# SPDX-FileCopyrightText: 2025 nabegator220
+# SPDX-FileCopyrightText: 2025 āda
+# SPDX-FileCopyrightText: 2026 DeusMaldPr
+# SPDX-FileCopyrightText: 2026 Princess Cheeseballs
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: reagent
   id: Cryptobiolin
   name: reagent-name-cryptobiolin

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -335,8 +335,12 @@
       - !type:HealthChange
         conditions:
           # they gotta be in crit first
-        - !type:MobStateCondition
-          mobstate: Critical
+        #klovn start
+#        - !type:MobStateCondition
+#          mobstate: Critical
+        - !type:TotalDamageCondition #theoreitcally this fucks over mobs with less than 100 hp, ideally it should apply for both
+          min: 90
+          #Klovn end
         - !type:ReagentCondition
           reagent: Epinephrine
           max: 20
@@ -345,8 +349,8 @@
             Asphyxiation: -3
             Poison: -0.5
           groups:
-            Brute: -0.5
-            Burn: -0.5
+            Brute: -1 #klovn, was 0.5, felt like it did Nothing
+            Burn: -0.7 #klovn, was 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -815,7 +819,7 @@
       - !type:HealthChange
         conditions:
         - !type:TotalDamageCondition
-          max: 50
+          max: 100 #klovn
         damage:
           groups:
             Brute: -1
@@ -1454,6 +1458,7 @@
   color: "#baa15d"
   metabolisms:
     Medicine:
+      metabolismRate: 0.25 #klovn
       effects:
       - !type:GenericStatusEffect
         key: RadiationProtection
@@ -1467,7 +1472,16 @@
             min: 20
         damage:
           types:
-            Poison: 1
+            Poison: 0.5 #klovn start
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentCondition
+          reagent: PotassiumIodide
+          max: 20
+        damage:
+          types:
+            Radiation: -0.1
+        probability: 0.5 #Klovn end
 
 - type: reagent
   id: Haloperidol


### PR DESCRIPTION
## About the PR
opinionated man makes pr (title)

## Why
See cl for context
epi healing as little as it did made it feel weak, potassium iodine healing rads is to reward pre-emptive pops slightly more and to make an easy to make anti rad med Exist (though its not exactly good for that purpose lol) ditto for metabolism changes 
also allows us to make rads more deadly DTL, id personally suggest mapping it's pill canisters in engi more 🤷‍♂️ 
trico changes so trico is a Real chem (though its still weak, lol!)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I did actually test this ingame till it felt right
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Tricordizene now heals you if you aren't crit, not just up to 50 damage.
- tweak: Epinephrine heals slightly more and will now heal to 90 damage (instead of just 100, ie, slightly over crit, not just right at it)
- tweak: Potassium iodine will heal SLIGHT amounts of rad damage aswell as metabolize 50% slower than before. 
