### PR TITLE
biocube buff

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -143,13 +143,13 @@
 # SPDX-FileCopyrightText: 2025 Vasilis The Pikachu
 # SPDX-FileCopyrightText: 2025 Velken
 # SPDX-FileCopyrightText: 2025 deltanedas
-# SPDX-FileCopyrightText: 2025 github_actions[bot]
 # SPDX-FileCopyrightText: 2025 kosticia
 # SPDX-FileCopyrightText: 2025 nabegator220
 # SPDX-FileCopyrightText: 2025 pathetic meowmeow
 # SPDX-FileCopyrightText: 2025 slarticodefast
 # SPDX-FileCopyrightText: 2025 āda
 # SPDX-FileCopyrightText: 2026 FrauzJ
+# SPDX-FileCopyrightText: 2026 github_actions[bot]
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -129,21 +129,27 @@
 # SPDX-FileCopyrightText: 2024 takemysoult
 # SPDX-FileCopyrightText: 2024 to4no_fix
 # SPDX-FileCopyrightText: 2025 ArtisticRoomba
+# SPDX-FileCopyrightText: 2025 Connor Huffine
 # SPDX-FileCopyrightText: 2025 DeusMaldPr
 # SPDX-FileCopyrightText: 2025 Hitlinemoss
+# SPDX-FileCopyrightText: 2025 Jessica M
 # SPDX-FileCopyrightText: 2025 K-Dynamic
 # SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
 # SPDX-FileCopyrightText: 2025 Nemanja
 # SPDX-FileCopyrightText: 2025 OnyxTheBrave
+# SPDX-FileCopyrightText: 2025 PJB3005
 # SPDX-FileCopyrightText: 2025 Perry Fraser
 # SPDX-FileCopyrightText: 2025 Southbridge
+# SPDX-FileCopyrightText: 2025 Vasilis The Pikachu
 # SPDX-FileCopyrightText: 2025 Velken
 # SPDX-FileCopyrightText: 2025 deltanedas
 # SPDX-FileCopyrightText: 2025 github_actions[bot]
 # SPDX-FileCopyrightText: 2025 kosticia
+# SPDX-FileCopyrightText: 2025 nabegator220
 # SPDX-FileCopyrightText: 2025 pathetic meowmeow
 # SPDX-FileCopyrightText: 2025 slarticodefast
 # SPDX-FileCopyrightText: 2025 āda
+# SPDX-FileCopyrightText: 2026 FrauzJ
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -502,6 +502,7 @@
   - type: Lathe
     idleState: icon
     runningState: building
+    timeMultiplier: 2 #KS14 change to speed shit up
     staticPacks:
     - FriendlyCubesStatic
   - type: EmagLatheRecipes

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -63,7 +63,7 @@
   result: SpaceCarpCube
   materials:
     Biomass: 24
-    Gold: 200 # KS14 change from plasma to gold
+    GoldIngot: 200 # KS14 change from plasma to gold
 
 - type: latheRecipe
   parent: BaseCubeRecipe
@@ -72,7 +72,7 @@
   completetime: 15
   materials:
     Biomass: 8
-    Gold: 100 # less biomass but more plasma, # KS14 change from plasma to gold
+    GoldIngot: 100 # less biomass but more plasma, # KS14 change from plasma to gold
 
 - type: latheRecipe
   parent: BaseCubeRecipe
@@ -80,4 +80,4 @@
   result: AbominationCube
   materials: # abominations are slow and essentially worse than even carp
     Biomass: 28
-    Gold: 100 # more biomass but less plasma, # KS14 change from plasma to gold
+    GoldIngot: 100 # more biomass but less plasma, # KS14 change from plasma to gold

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Ilya246
 # SPDX-FileCopyrightText: 2024 deltanedas
 # SPDX-FileCopyrightText: 2026 FrauzJ
+# SPDX-FileCopyrightText: 2026 github_actions[bot]
 #
 # SPDX-License-Identifier: MPL-2.0
 

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -63,7 +63,7 @@
   result: SpaceCarpCube
   materials:
     Biomass: 24
-    Plasma: 600
+    Gold: 200 # KS14 change from plasma to gold
 
 - type: latheRecipe
   parent: BaseCubeRecipe
@@ -72,7 +72,7 @@
   completetime: 15
   materials:
     Biomass: 8
-    Plasma: 300 # less biomass but more plasma
+    Gold: 100 # less biomass but more plasma, # KS14 change from plasma to gold
 
 - type: latheRecipe
   parent: BaseCubeRecipe
@@ -80,4 +80,4 @@
   result: AbominationCube
   materials: # abominations are slow and essentially worse than even carp
     Biomass: 28
-    Plasma: 500 # more biomass but less plasma
+    Gold: 100 # more biomass but less plasma, # KS14 change from plasma to gold

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Ilya246
+# SPDX-FileCopyrightText: 2024 deltanedas
+# SPDX-FileCopyrightText: 2026 FrauzJ
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Base prototypes
 
 - type: latheRecipe


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- READ THIS BEFORE CONTRIBUTING TO KS14!!!
The REUSE Specification headers or separate .license files indicate a secondary license (if any, but e.g., the MPL or MIT licenses) alongside the AGPL, solely to facilitate
integration for projects that do not fall under a single license.

REUSE headers will be automatically added via github workflow. You can edit the SPDX-License-Identifier to change the license that the file is specified as having.
SPDX license identifiers already included in files relevant to the PR, or identifiers that were manually changed after being automatically added, will not be modified by the bot.

For clarity: You are recommended to have PR-relevant upstream-original (wizden's) files be licensed as MIT. KS14 uses the MPL license for content original to KS14.
This individual comment block can be safely removed, but you must preserve the below comment block specifying the default license of this PR.

Uncomment and modify the following line if you wish to change the auto-added license from the default of MPL. Set to `AGPL` for AGPL-3.0-or-later, `MPL` for MPL-2.0, and `MIT` for MIT.
-->
<!--- LICENSE: MPL -->
## About the PR
<!-- What did you change? -->
changes biocube prices for antag shit to be in gold instead of plasma, makes them cheaper
speeds up production by 2x
## Why
<!-- Explain why this was changed. -->
too expensive rn
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [no] Tested, works.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Biocube fabricator prices for emagged cubes were changed to use gold instead of plasma. Botany farmers, rejoice.