### PR TITLE
brute meds

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -145,10 +145,11 @@
   color: "#ffaa00"
   metabolisms:
     Bloodstream:
+      metabolismRate: 0.25 #KS14 change
       effects:
       - !type:EvenHealthChange
         damage:
-          Brute: -1.5
+          Brute: -1 #ks14, see above
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -1077,10 +1078,11 @@
       metabolismRate: 0.25
       effects:
       - !type:HealthChange
-        damage:
+        damage: #ks14 changed
           types:
             Slash: -2 # 8 per u
-            Heat: 0.2 # 0.8 per u
+            Piercing: -0.25
+            Blunt: -0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -1104,9 +1106,10 @@
       effects:
       - !type:HealthChange
         damage:
-          types:
-            Piercing: -2.5 # 10 per u
-            Radiation: 0.05 # 0.2 per u, 3 for 15u
+          types: #ks14 changed
+            Piercing: -2.25 # 9 per u
+            Slash: 0.25
+            Blunt: -0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -1130,8 +1133,10 @@
       effects:
       - !type:HealthChange
         damage:
-          types:
+          types: #ks14 changed
             Blunt: -2.25 # 9 per u
+            Piercing: -0.25
+            Slash: -0.25
       - !type:SatiateHunger
         factor: -1
       - !type:HealthChange


### PR DESCRIPTION
## What was changed
bicard heals slower but heals 4/u instead of 3u (25% increase overall)
slash punct and bruizine now heal the secondary damage types 1/4th as good as bicard (its a nothingburger but slight QOL so you dont need to inject all 3 fucking meds) 

## Why
I think its better like this, the minor dmg the advanced meds heal are a nothingburger

## Requirements
- [X] Tested, works.

**Changelog**
:cl:
- tweak: Bicardine heals slightly more but heals it slower (3/u > 4dmg/u)
- tweak: T2 Brute meds now heal very small amounts of the brute damage type they're not specialized for, and don't deal residual damage.
