### PR TITLE
delimb tweaks

### DIFF
--- a/Content.Client/_KS14/PredictedSpawning/KsPredictedSpawnSystem.cs
+++ b/Content.Client/_KS14/PredictedSpawning/KsPredictedSpawnSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._KS14.PredictedSpawning;
+using Robust.Client.GameObjects;
 using Robust.Client.Physics;
 
 namespace Content.Client._KS14.PredictedSpawning;
@@ -11,10 +12,21 @@ public sealed class KsPredictedSpawnSystem : KsSharedPredictedSpawnSystem
         base.Initialize();
 
         SubscribeLocalEvent<KsPredictedSpawnComponent, UpdateIsPredictedEvent>(OnPredictedSpawnCheckPhysicsPrediction);
+        SubscribeNetworkEvent<KsPredictedEntitySpawnedEvent>(OnEntityNetworked);
     }
 
     private void OnPredictedSpawnCheckPhysicsPrediction(Entity<KsPredictedSpawnComponent> entity, ref UpdateIsPredictedEvent args)
     {
         args.IsPredicted = true;
+    }
+
+    private void OnEntityNetworked(KsPredictedEntitySpawnedEvent args)
+    {
+        var uid = GetEntity(args.Entity);
+        if (!uid.IsValid())
+            return;
+
+        PredictedDel(uid);
+        RemComp<SpriteComponent>(uid);
     }
 }

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Klovn.Dismemberment.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Klovn.Dismemberment.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared._KS14.BloodSpray;
 using Content.Shared._KS14.Klovnmed;
 using Content.Shared._KS14.Klovnmed.Dismemberment;
+using Content.Shared._KS14.Random.Helpers;
 using Content.Shared.Body;
 using Content.Shared.Body.Components;
 
@@ -14,8 +15,8 @@ public sealed partial class ExplosionSystem
     [Dependency] private readonly DismembermentSystem _dismembermentSystem = default!;
     [Dependency] private readonly BloodSpraySystem _bloodSpraySystem = default!;
 
-    private readonly float[] _dismembermentTargetDistanceKeys = [0f, 0f, 1.25f, 2.5f, 7.5f]; // should be same length as below
-    private readonly BodyPartType[] _dismembermentTargetDistanceValues = [BodyPartType.Foot, BodyPartType.Leg, BodyPartType.Hand, BodyPartType.Arm, BodyPartType.Head]; // should be same length as above
+    private readonly float[] _dismembermentTargetDistanceKeys = [0f, 1.25f, 2.5f, 7.5f]; // should be same length as below
+    private readonly BodyPartType[] _dismembermentTargetDistanceValues = [BodyPartType.Leg, BodyPartType.Hand, BodyPartType.Arm, BodyPartType.Head]; // should be same length as above
 
     // holy hardcoding
     private void HandleExplosionDamage(Entity<BodyComponent?> entity, float throwForce, float totalDamage, EntityUid? cause, Vector2 worldEpicenter, TransformComponent? transformComponent)
@@ -45,9 +46,14 @@ public sealed partial class ExplosionSystem
         // maximum of 1 to (1 to 2) maximum number of dismemberments
 
         var distanceWithMinimumOne = Math.Max(1f, distance);
+        var predictedRandom = KsSharedRandomExtensions.RandomWithHashCodeCombinedSeed(
+            (int)_timing.CurTick.Value,
+            KsSharedRandomExtensions.GetNetId(entity.Owner, EntityManager),
+            (int)totalDamage
+        );
 
         // maximum potential dismemberments gets lower with distance
-        var maximumDismemberments = Math.Min(Math.Max(1, (int)(3f / distanceWithMinimumOne)), _robustRandom.Next(1, 3)); // IDFK
+        var maximumDismemberments = Math.Min(Math.Max(1, (int)(3f / distanceWithMinimumOne)), predictedRandom.Next(1, 3)); // IDFK
 
         for (var i = 0; i < maximumDismemberments; i++)
         {
@@ -57,7 +63,8 @@ public sealed partial class ExplosionSystem
                 out _,
                 direction: positionalDelta,
                 throwSpeed: throwForce * 0.65f,
-                cause: cause
+                cause: cause,
+                predictedRandom: predictedRandom
             );
         }
 

--- a/Content.Server/_KS14/PredictedSpawning/KsPredictedSpawnSystem.cs
+++ b/Content.Server/_KS14/PredictedSpawning/KsPredictedSpawnSystem.cs
@@ -3,4 +3,16 @@ using Content.Shared._KS14.PredictedSpawning;
 namespace Content.Server._KS14.PredictedSpawning;
 
 /// <inheritdoc/>
-public sealed class KsPredictedSpawnSystem : KsSharedPredictedSpawnSystem;
+public sealed class KsPredictedSpawnSystem : KsSharedPredictedSpawnSystem
+{
+    protected override EntityUid FlagPredictedAndReturn(EntityUid uid, EntityUid? user = null)
+    {
+        if (user is { })
+        {
+            var args = new KsPredictedEntitySpawnedEvent(GetNetEntity(uid));
+            RaiseNetworkEvent(args, user.Value);
+        }
+
+        return base.FlagPredictedAndReturn(uid);
+    }
+}

--- a/Content.Shared/Body/BodyComponent.cs
+++ b/Content.Shared/Body/BodyComponent.cs
@@ -48,7 +48,7 @@ public sealed partial class BodyComponent : Component, IHierarchyComponent // KS
     ///         to dismember SOMETHING.
     /// </summary>
     [DataField]
-    public FixedPoint2 DismembermentThreshold = FixedPoint2.New(70f);
+    public FixedPoint2 DismembermentThreshold = FixedPoint2.New(80f);
 }
 
 /// <summary>

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -313,6 +313,14 @@ public sealed partial class DoorComponent : Component
     [DataField]
     public _KS14.Klovnmed.BodyPartType? CrushableBodyPartType = null;
 
+    // KS14
+    /// <summary>
+    ///     Minimum total damage before bodyparts can be dismembered.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
+    public float CrushDelimbDamageThreshold = 0f;
+
     [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int OpenDrawDepth = (int)DrawDepth.DrawDepth.Doors;
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -537,6 +537,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
             // KS14: Crush dismemberment start
             if (door.CrushableBodyPartType is { } crushableType &&
+                _damageableSystem.GetTotalDamage(entity) >= door.CrushDelimbDamageThreshold &&
                 _dismembermentSystem.TryDismemberRandomBodyPartOfType(entity, crushableType, out var partUid, cause: uid))
             {
                 _dismembermentSystem.DoFixedEmote(entity);

--- a/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._KS14.Sparks; // KS14: sparks on light breaking
 using Content.Shared.Audio;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
@@ -36,6 +37,7 @@ public abstract class SharedPoweredLightSystem : EntitySystem
     [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedDeviceLinkSystem _deviceLink = default!;
+    [Dependency] private readonly SharedSparksSystem _sparksSystem = default!; // KS14: sparks on light breaking
 
     private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(2);
     public const string LightBulbContainer = "light_bulb";
@@ -244,6 +246,18 @@ public abstract class SharedPoweredLightSystem : EntitySystem
             return false;
         if (lightBulb.State == LightBulbState.Broken)
             return false;
+
+        // KS14 start: sparks on light breaking
+        if (light.CurrentLit)
+        {
+            _sparksSystem.DoSparks(
+                Transform(uid).Coordinates,
+                SharedSparksSystem.DefaultSparkPrototype,
+                soundSpecifier: SharedSparksSystem.DefaultSoundSpecifier,
+                maximumSparks: 3
+            );
+        }
+        // KS14 end: sparks on light breaking
 
         // break it
         _bulbSystem.SetState(bulbUid.Value, LightBulbState.Broken, lightBulb);

--- a/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
@@ -254,7 +254,8 @@ public abstract class SharedPoweredLightSystem : EntitySystem
                 Transform(uid).Coordinates,
                 SharedSparksSystem.DefaultSparkPrototype,
                 soundSpecifier: SharedSparksSystem.DefaultSoundSpecifier,
-                maximumSparks: 3
+                maximumSparks: 3,
+                user: user
             );
         }
         // KS14 end: sparks on light breaking

--- a/Content.Shared/Movement/Components/ActiveLeaperComponent.cs
+++ b/Content.Shared/Movement/Components/ActiveLeaperComponent.cs
@@ -16,15 +16,14 @@ public sealed partial class ActiveLeaperComponent : Component
 
     // KS14
     [DataField]
-    public bool HitAnything = false;
+    public bool Punish = true;
 
     // KS14 addition
     /// <summary>
     /// If specified, this is how long to stun the owner for if they collided with the environment.
-    ///     Otherwise, they will be knocked down with this duration if they hit something.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public TimeSpan? GuaranteedKnockdownDuration = null;
+    public TimeSpan? PunishStunDuration = null;
 
     // KS14 addition
     /// <summary>

--- a/Content.Shared/Movement/Components/ActiveLeaperComponent.cs
+++ b/Content.Shared/Movement/Components/ActiveLeaperComponent.cs
@@ -14,10 +14,14 @@ public sealed partial class ActiveLeaperComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan? KnockdownDuration = null; // KS14: Made optional
 
+    // KS14
+    [DataField]
+    public bool HitAnything = false;
+
     // KS14 addition
     /// <summary>
-    /// If specified, this is how long to stun the owner for if they didn't collide with the
-    /// environment after finishing the leap.
+    /// If specified, this is how long to stun the owner for if they collided with the environment.
+    ///     Otherwise, they will be knocked down with this duration if they hit something.
     /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan? GuaranteedKnockdownDuration = null;

--- a/Content.Shared/Movement/Components/JumpAbilityComponent.cs
+++ b/Content.Shared/Movement/Components/JumpAbilityComponent.cs
@@ -55,10 +55,10 @@ public sealed partial class JumpAbilityComponent : Component
     /// The duration of the knockdown after finishing a jump, when <see cref="KnockdownOnFinish"/>
     /// is true.
     ///
-    /// Not applied after a collision, if <see cref="CanCollide"/> is true or this is null.
+    /// Not applied after a collision with something that gets knocked down, if <see cref="CanCollide"/> is true or this is null.
     /// </summary>
     [DataField]
-    public TimeSpan? FinishKnockdown = TimeSpan.FromSeconds(1);
+    public TimeSpan? PunishKnockdown = TimeSpan.FromSeconds(1);
 
     // KS14 addition
     /// <summary>

--- a/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
@@ -63,33 +63,50 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
 
     private void OnLeaperCollide(Entity<ActiveLeaperComponent> entity, ref StartCollideEvent args)
     {
+        if (!_gameTiming.IsFirstTimePredicted) // KS14
+            return;
+
         if (entity.Comp.KnockdownDuration is { } collisionKnockdownDuration) // KS14 change: made optional
             _stun.TryKnockdown(entity.Owner, collisionKnockdownDuration);
 
-        if (entity.Comp.StaminaDamage != 0f && _gameTiming.IsFirstTimePredicted /* which genius thought to predict this event */) // KS14 addition
+        if (entity.Comp.StaminaDamage != 0f) // KS14 addition
             _staminaSystem.TakeStaminaDamage(args.OtherEntity, entity.Comp.StaminaDamage);
 
         if (entity.Comp.HitKnockdownDuration is { } hitKnockdownDuration && _gameTiming.IsFirstTimePredicted) // KS14 addition
-            _stun.TryKnockdown(args.OtherEntity, hitKnockdownDuration, force: true);
-
-        if (entity.Comp.GuaranteedKnockdownDuration is { } guaranteedKnockdownDuration) // KS14 addition, instead of stunning, knock them down if they hit something
-            _stun.TryKnockdown(entity.Owner, guaranteedKnockdownDuration, force: true, refresh: false, drop: false);
-
-        entity.Comp.HitAnything = true; // KS14
+            entity.Comp.Punish = !_stun.TryKnockdown(args.OtherEntity, hitKnockdownDuration, refresh: false, force: true);
+        else
+            entity.Comp.Punish = true;
 
         RemCompDeferred<ActiveLeaperComponent>(entity);
     }
 
+    /*
+    punished = true;
+    knocked = false;
+
+    if (punished || knocked)
+        punished = true
+        => punished = true
+
+    if (punished(true) || !knocked(!false => true))
+        punished = true
+        => punished = true
+
+    if (punished(true) || knocked(true))
+        punished = false
+        => punished = true
+    */
+
     private void OnLeaperLand(Entity<ActiveLeaperComponent> entity, ref LandEvent args)
     {
-        if (entity.Comp.HitAnything) // KS14 addition
+        if (!entity.Comp.Punish) // KS14 addition
         {
             return;
         }
         else
         {
             // Stun them if they didnt hit anything to break their fall
-            if (entity.Comp.GuaranteedKnockdownDuration is { } guaranteedKnockdownDuration) // KS14 addition
+            if (entity.Comp.PunishStunDuration is { } guaranteedKnockdownDuration) // KS14 addition
             {
                 _stun.TryAddStunDuration(entity.Owner, guaranteedKnockdownDuration);
                 _stun.TryKnockdown(entity.Owner, guaranteedKnockdownDuration, force: true, refresh: false, drop: true);
@@ -155,7 +172,7 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
             leaperComp.HitKnockdownDuration = entity.Comp.HitKnockdownDuration;
         }
 
-        leaperComp.GuaranteedKnockdownDuration = entity.Comp.FinishKnockdown; // KS14 addition
+        leaperComp.PunishStunDuration = entity.Comp.PunishKnockdown; // KS14 addition
         Dirty(entity.Owner, leaperComp);
 
         args.Handled = true;
@@ -171,7 +188,7 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
         targetComp.CanCollide = ent.Comp.CanCollide;
         targetComp.JumpSound = ent.Comp.JumpSound;
         targetComp.CollideKnockdown = ent.Comp.CollideKnockdown;
-        targetComp.FinishKnockdown = ent.Comp.FinishKnockdown; // KS14 change
+        targetComp.PunishKnockdown = ent.Comp.PunishKnockdown; // KS14 change
         targetComp.JumpDistance = ent.Comp.JumpDistance;
         targetComp.JumpThrowSpeed = ent.Comp.JumpThrowSpeed;
         AddComp(args.CloneUid, targetComp, true);

--- a/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
@@ -64,7 +64,7 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
     private void OnLeaperCollide(Entity<ActiveLeaperComponent> entity, ref StartCollideEvent args)
     {
         if (entity.Comp.KnockdownDuration is { } collisionKnockdownDuration) // KS14 change: made optional
-            _stun.TryKnockdown(entity.Owner, collisionKnockdownDuration, force: true);
+            _stun.TryKnockdown(entity.Owner, collisionKnockdownDuration);
 
         if (entity.Comp.StaminaDamage != 0f && _gameTiming.IsFirstTimePredicted /* which genius thought to predict this event */) // KS14 addition
             _staminaSystem.TakeStaminaDamage(args.OtherEntity, entity.Comp.StaminaDamage);
@@ -72,13 +72,29 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
         if (entity.Comp.HitKnockdownDuration is { } hitKnockdownDuration && _gameTiming.IsFirstTimePredicted) // KS14 addition
             _stun.TryKnockdown(args.OtherEntity, hitKnockdownDuration, force: true);
 
+        if (entity.Comp.GuaranteedKnockdownDuration is { } guaranteedKnockdownDuration) // KS14 addition, instead of stunning, knock them down if they hit something
+            _stun.TryKnockdown(entity.Owner, guaranteedKnockdownDuration, force: true, refresh: false, drop: false);
+
+        entity.Comp.HitAnything = true; // KS14
+
         RemCompDeferred<ActiveLeaperComponent>(entity);
     }
 
     private void OnLeaperLand(Entity<ActiveLeaperComponent> entity, ref LandEvent args)
     {
-        if (entity.Comp.GuaranteedKnockdownDuration is { } guaranteedKnockdownDuration) // KS14 addition
-            _stun.TryKnockdown(entity.Owner, guaranteedKnockdownDuration, force: true, refresh: false, drop: false);
+        if (entity.Comp.HitAnything) // KS14 addition
+        {
+            return;
+        }
+        else
+        {
+            // Stun them if they didnt hit anything to break their fall
+            if (entity.Comp.GuaranteedKnockdownDuration is { } guaranteedKnockdownDuration) // KS14 addition
+            {
+                _stun.TryAddStunDuration(entity.Owner, guaranteedKnockdownDuration);
+                _stun.TryKnockdown(entity.Owner, guaranteedKnockdownDuration, force: true, refresh: false, drop: true);
+            }
+        }
 
         RemCompDeferred<ActiveLeaperComponent>(entity);
     }

--- a/Content.Shared/_KS14/BloodSpray/BloodSpraySystem.cs
+++ b/Content.Shared/_KS14/BloodSpray/BloodSpraySystem.cs
@@ -29,6 +29,16 @@ public sealed class BloodSpraySystem : EntitySystem
     private static readonly QueryFilter StaticQueryFilter = new() { LayerBits = 1L, Flags = QueryFlags.Static, MaskBits = (long)CollisionGroup.Impassable };
     private static readonly Vector2 DecalOffset = Vector2.One / 2; // KS14 Addition; this is related to texture size of the blood splatter.
 
+    private EntityUid RecursivelyGetGridOrMapUid(TransformComponent transformComponent)
+    {
+        if (transformComponent.GridUid is { })
+            return transformComponent.GridUid.Value;
+        else if (transformComponent.MapUid == transformComponent.ParentUid)
+            return transformComponent.ParentUid;
+
+        return RecursivelyGetGridOrMapUid(Transform(transformComponent.ParentUid));
+    }
+
     public void HandleBleedEffects(Entity<BloodstreamComponent?> entity, DamageSpecifier bloodlossSpecifier, EntityUid originUid)
         => HandleBleedEffects(entity, (float)bloodlossSpecifier.GetTotal(), originUid);
 
@@ -43,7 +53,7 @@ public sealed class BloodSpraySystem : EntitySystem
         var worldDeltaUnit = _transformSystem.GetWorldPosition(targetTransform) - _transformSystem.GetWorldPosition(originTransform);
 
         Vector2Helpers.Normalize(ref worldDeltaUnit);
-        HandleBleedEffects(entity!, bloodloss, targetTransform, originTransform.ParentUid, worldDeltaUnit);
+        HandleBleedEffects(entity!, bloodloss, targetTransform, RecursivelyGetGridOrMapUid(originTransform), worldDeltaUnit);
     }
 
     // TODO: Clean up code

--- a/Content.Shared/_KS14/Klovnmed/Dismemberment/DismembermentSystem.cs
+++ b/Content.Shared/_KS14/Klovnmed/Dismemberment/DismembermentSystem.cs
@@ -61,15 +61,22 @@ public sealed class DismembermentSystem : EntitySystem
     ///     Supports <see cref="partType"/> having more than one bit set.
     /// </summary>
     /// <returns>Whether anything happened.</returns>
-    public bool TryDismemberRandomBodyPartOfType(Entity<BodyComponent?, TransformComponent?> bodyEntity, BodyPartType partType, [NotNullWhen(true)] out EntityUid? partUid, Vector2? direction = null, float throwSpeed = 10f, EntityUid? cause = null)
+    // wall of parameters
+    public bool TryDismemberRandomBodyPartOfType(Entity<BodyComponent?, TransformComponent?> bodyEntity, BodyPartType partType, [NotNullWhen(true)] out EntityUid? partUid, Vector2? direction = null, float throwSpeed = 10f, EntityUid? cause = null, System.Random? predictedRandom = null)
     {
         if (!_bodyQuery.Resolve(bodyEntity, ref bodyEntity.Comp1, logMissing: false) ||
             !EntityManager.TransformQuery.Resolve(bodyEntity, ref bodyEntity.Comp2, logMissing: true) ||
-            !_organSearchSystem.TryGetRandomBodyPartOfType((bodyEntity, bodyEntity.Comp1), partType, out var predictedRandom, out partUid))
+            !_organSearchSystem.TryGetRandomBodyPartOfType((bodyEntity, bodyEntity.Comp1), partType, out predictedRandom, out partUid))
         {
             partUid = null;
             return false;
         }
+
+        predictedRandom ??= KsSharedRandomExtensions.RandomWithHashCodeCombinedSeed(
+            (int)_gameTiming.CurTick.Value,
+            KsSharedRandomExtensions.GetNetId(bodyEntity.Owner, EntityManager),
+            (int)partType
+        );
 
         DismemberPart((bodyEntity.Owner, bodyEntity.Comp2), partUid.Value, direction: direction, throwSpeed: throwSpeed, cause: cause, predictedRandom: predictedRandom);
         return true;

--- a/Content.Shared/_KS14/PredictedSpawning/KsSharedPredictedSpawnSystem.cs
+++ b/Content.Shared/_KS14/PredictedSpawning/KsSharedPredictedSpawnSystem.cs
@@ -2,6 +2,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Content.Shared._KS14.PredictedSpawning;
@@ -28,26 +29,33 @@ public abstract class KsSharedPredictedSpawnSystem : EntitySystem
     ///     Does predicted spawn as usual, while predicting physics too.
     ///         If specified user is notnull,
     /// </remarks>
-    public EntityUid PredictedSpawn(string entityProtoId, ComponentRegistry? componentOverrides = null, bool doMapInit = false)
-        => FlagPredictedAndReturn(EntityManager.PredictedSpawn(entityProtoId, overrides: componentOverrides, doMapInit: doMapInit));
+    public EntityUid PredictedSpawn(string entityProtoId, ComponentRegistry? componentOverrides = null, bool doMapInit = false, EntityUid? user = null)
+        => FlagPredictedAndReturn(EntityManager.PredictedSpawn(entityProtoId, overrides: componentOverrides, doMapInit: doMapInit), user);
 
     /// <inheritdoc cref="PredictedSpawn(string, ComponentRegistry?, bool)"/>
-    public EntityUid PredictedSpawn(string entityProtoId, MapCoordinates coordinates, ComponentRegistry? componentOverrides = null, Angle rotation = default)
-        => FlagPredictedAndReturn(EntityManager.PredictedSpawn(entityProtoId, coordinates, overrides: componentOverrides, rotation: rotation));
+    public EntityUid PredictedSpawn(string entityProtoId, MapCoordinates coordinates, ComponentRegistry? componentOverrides = null, Angle rotation = default, EntityUid? user = null)
+        => FlagPredictedAndReturn(EntityManager.PredictedSpawn(entityProtoId, coordinates, overrides: componentOverrides, rotation: rotation), user);
 
     /// <inheritdoc cref="PredictedSpawn(string, ComponentRegistry?, bool)"/>
-    public new EntityUid PredictedSpawnAttachedTo(string entityProtoId, EntityCoordinates coordinates, ComponentRegistry? componentOverrides = null, Angle rotation = default)
-        => FlagPredictedAndReturn(PredictedSpawnAttachedTo(entityProtoId, coordinates, overrides: componentOverrides, rotation: rotation));
+    public EntityUid PredictedSpawnAttachedTo(string entityProtoId, EntityCoordinates coordinates, ComponentRegistry? componentOverrides = null, Angle rotation = default, EntityUid? user = null)
+        => FlagPredictedAndReturn(PredictedSpawnAttachedTo(entityProtoId, coordinates, overrides: componentOverrides, rotation: rotation), user);
 
     /// <summary>
     ///     Flags the given entity as predicted.
     /// </summary>
     /// <returns>Same <see cref="EntityUid"/> as the one provided, so that some method definitions can be one-lined.</returns>
-    private EntityUid FlagPredictedAndReturn(EntityUid uid)
+    protected virtual EntityUid FlagPredictedAndReturn(EntityUid uid, EntityUid? user = null)
     {
+        EnsureComp<KsPredictedSpawnComponent>(uid);
         if (_physicsQuery.HasComponent(uid))
             _physicsSystem.UpdateIsPredicted(uid);
 
         return uid;
     }
+}
+
+[Serializable, NetSerializable]
+public sealed class KsPredictedEntitySpawnedEvent(NetEntity entity) : EntityEventArgs
+{
+    public NetEntity Entity = entity;
 }

--- a/Content.Shared/_KS14/Sparks/SharedSparksSystem.cs
+++ b/Content.Shared/_KS14/Sparks/SharedSparksSystem.cs
@@ -35,8 +35,8 @@ public abstract class SharedSparksSystem : EntitySystem
     /// <summary>
     ///     Spawns a random number of sparks attached to a position, each launched in a random direction at a random velocity.
     ///         Optionally also plays a sound at the given position.
-    /// 
-    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>. 
+    ///
+    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>.
     /// </summary>
     public void DoSparks(
         in EntityCoordinates coordinates,
@@ -63,7 +63,7 @@ public abstract class SharedSparksSystem : EntitySystem
 
     /// <summary>
     ///     Spawns a random number of sparks attached to a position, each launched in a random direction at a random velocity.
-    ///         Plays a soundcollection (<see cref="DefaultSoundSpecifier"/>) and spawns the default entity prototype, being <see cref="DefaultSparkPrototype"/>. 
+    ///         Plays a soundcollection (<see cref="DefaultSoundSpecifier"/>) and spawns the default entity prototype, being <see cref="DefaultSparkPrototype"/>.
     /// </summary>
     public void DoSparks(
         in EntityCoordinates coordinates,
@@ -79,8 +79,8 @@ public abstract class SharedSparksSystem : EntitySystem
     /// <summary>
     ///     Spawns a single spark attached to a position, and launches it in a random direction at a random velocity.
     ///         Optionally also plays a sound at the given position.
-    /// 
-    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>. 
+    ///
+    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>.
     /// </summary>
     /// <param name="random">Random used to get velocity and direction of the spark. Should have a predicted seed if this method is being used in prediction.</param>
     /// <returns>The spawned entity.</returns>
@@ -94,7 +94,7 @@ public abstract class SharedSparksSystem : EntitySystem
         System.Random? random = null
     )
     {
-        var spark = _ksPredictedSpawnSystem.PredictedSpawn(sparkPrototype);
+        var spark = _ksPredictedSpawnSystem.PredictedSpawn(sparkPrototype, user: user);
         random ??= KsSharedRandomExtensions.RandomWithHashCodeCombinedSeed(
             (int)_gameTiming.CurTick.Value,
             KsSharedRandomExtensions.GetNetId(spark, EntityManager),
@@ -114,14 +114,14 @@ public abstract class SharedSparksSystem : EntitySystem
 
     /// <summary>
     ///     Spawns a single spark at a position, and launches it in a given direction at a given velocity.
-    /// 
-    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>. 
+    ///
+    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>.
     /// </summary>
     /// <returns>The spawned entity.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EntityUid SpawnSpark(in MapCoordinates coordinates, in Vector2 velocityVector, in EntProtoId sparkPrototype)
+    public EntityUid SpawnSpark(in MapCoordinates coordinates, in Vector2 velocityVector, in EntProtoId sparkPrototype, in Entity<MetaDataComponent?>? user = null)
     {
-        var spark = _ksPredictedSpawnSystem.PredictedSpawn(sparkPrototype, coordinates);
+        var spark = _ksPredictedSpawnSystem.PredictedSpawn(sparkPrototype, coordinates, user: user);
         _physicsSystem.SetLinearVelocity(spark, velocityVector);
 
         return spark;
@@ -134,14 +134,14 @@ public abstract class SharedSparksSystem : EntitySystem
 
     /// <summary>
     ///     Spawns a single spark attached to a position, and launches it in a given direction at a given velocity.
-    /// 
-    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>. 
+    ///
+    ///     The spark entity defined in <paramref name="sparkPrototype"/> should have a <see cref="Robust.Shared.Physics.Components.PhysicsComponent"/>.
     /// </summary>
     /// <returns>The spawned entity.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EntityUid SpawnSparkAttached(in EntityCoordinates coordinates, in Vector2 velocityVector, in EntProtoId sparkPrototype)
+    public EntityUid SpawnSparkAttached(in EntityCoordinates coordinates, in Vector2 velocityVector, in EntProtoId sparkPrototype, in Entity<MetaDataComponent?>? user = null)
     {
-        var spark = _ksPredictedSpawnSystem.PredictedSpawnAttachedTo(sparkPrototype, coordinates);
+        var spark = _ksPredictedSpawnSystem.PredictedSpawnAttachedTo(sparkPrototype, coordinates, user: user);
         _physicsSystem.SetLinearVelocity(spark, velocityVector);
 
         return spark;

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -100,7 +100,8 @@
       # KS14 start
       performCollisionCheck: false
       forcedCollisionCheckOnClick: true
-      crushableBodyPartType: [ Arm, Leg, Hand, Foot ]
+      crushableBodyPartType: [ Arm, Leg, Hand ]
+      crushDelimbDamageThreshold: 90
       # KS14 end
       openDrawDepth: WallTops
       closeTimeOne: 0.1

--- a/Resources/Prototypes/_KS14/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_KS14/Entities/Mobs/base.yml
@@ -9,8 +9,8 @@
     canCollide: true
     jumpDistance: 1.25
     finishKnockdown: 0.85
-    hitStaminaDamage: 0
-    hitKnockdownDuration: 2
+    hitStaminaDamage: 10
+    hitKnockdownDuration: 3
     jumpSound:
       path: /Audio/Weapons/punchmiss.ogg
       params:

--- a/Resources/Prototypes/_KS14/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_KS14/Entities/Mobs/base.yml
@@ -8,9 +8,10 @@
     action: ActionGravityDive
     canCollide: true
     jumpDistance: 1.25
-    finishKnockdown: 0.85
+    punishKnockdown: 3.2
     hitStaminaDamage: 10
-    hitKnockdownDuration: 3
+    collideKnockdown: 2.2
+    hitKnockdownDuration: 3.2
     jumpSound:
       path: /Audio/Weapons/punchmiss.ogg
       params:


### PR DESCRIPTION
see cl

**Changelog**
:cl:
- tweak: Explosions now need to do more damage to delimb you. They will also no longer delimb feet.
- tweak: You must have atleast 90 total damage for firelocks to delimb you. They will also no longer delimb feet.
- fix: Fixed limbs thrown from explosion dismemberment being thrown in exact same direction. 
- tweak: Diving now fullstuns you if you dont hit anything, but doesnt if you hit something.
- tweak: Diving is now stronger against people getting hit.