### PR TITLE
make medical fills not Aids

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -126,16 +126,18 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: Bloodpack
-          amount: 2
+        - id: Brutepack #klovnstart
+        - id: Ointment
         - id: Gauze
+        - id: Bloodpack
         # Reagents focused on emergency response rather than outright healing
-        - id: ChemistryBottleInaprovaline
-          amount: 2
-        - id: ChemistryBottleHaloperidol
-        - id: ChemistryBottleEthylredoxrazine
-        - id: ChemistryBottleIpecac
-        - id: ChemistryBottleCharcoal
+        #kys wizden comment above mi
+        - id: ChemistryBottleBicaridine
+        - id: ChemistryBottleDylovene
+        - id: ChemistryBottleDexalin
+        - id: ChemistryBottleEpinephrine
+        - id: ChemistryBottleIpecac #larp
+        - id: ChemistryBottleCharcoal #klovnend
 
 - type: entity
   id: ClothingBeltPlantFilled

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -12,6 +12,7 @@
         - id: Ointment
         - id: Gauze
         - id: PillCanisterTricordrazine
+        - id: PillCanisterIron #ks14
       # see https://github.com/tgstation/blob/master/code/game/objects/items/storage/firstaid.dm for example contents
 
 - type: entity
@@ -38,6 +39,7 @@
       storagebase: !type:AllSelector
         children:
         - id: Brutepack
+          amount: 2 #ks14
         - id: Gauze
         - id: PillCanisterIron
         - id: PillCanisterCopper

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -44,9 +44,17 @@
   table: !type:AllSelector
     children:
     - id: ClothingEyesHudMedical
-    - id: ClothingBeltMedicalFilled
+    - id: ClothingBeltMedical # Filled KS14 - in loadout
     - id: JetInjector
     - id: HandheldHealthAnalyzer
+    - id: ClothingMaskSterile
+    - !type:GroupSelector #KS14
+      children:
+      - id: UniformScrubsColorPurple
+      - id: UniformScrubsColorGreen
+      - id: UniformScrubsColorBlue
+      - id: ClothingUniformJumpsuitMedicalDoctor
+      - id: ClothingUniformJumpskirtMedicalDoctor #KS14 end
     - id: ChemistryBottleLaughter # Widely recognized as the best medicine :o)
       prob: 0.01
     - id: PlushieLizardJobMedicaldoctor
@@ -120,10 +128,12 @@
     children:
     - id: ClothingEyesHudMedical
     - id: ClothingOuterHardsuitVoidParamed
-    - id: ClothingBeltMedicalEMTFilled
+    - id: ClothingBeltMedicalEMT # Filled - KS14, you spawn with it
     - id: JetInjector
     - id: HandheldHealthAnalyzer
     - id: BoxBodyBag
+    - id: HandheldCrewMonitor #klovn
+    - id: MedkitFilled #klovn
     - !type:GroupSelector
       children:
       - id: RollerBedSpawnFolded

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -6,7 +6,7 @@
     Brutepack: 3
     Ointment: 3
     Bloodpack: 3
-    ChemistryBottleEpinephrine: 3
+    ChemistryBottleEpinephrine: 2 #ks14, reduced to 2
     Syringe: 3
     PillCanisterTricordrazine: 2
   contrabandInventory:
@@ -32,12 +32,12 @@
   id: NanoMedPlusInventory
   startingInventory:
     # Medical Essential Gear
-    ClothingBeltMedicalFilled: 2
+    # ClothingBeltMedicalFilled: 2 KS14, moved to roundstart spawn in
     # Shared Essential
     HandheldHealthAnalyzer: 3
     JetInjector: 3
     # Paramed Essential Gear
-    ClothingBeltMedicalEMTFilled: 1
+    # ClothingBeltMedicalEMTFilled: 1 KS14 - Moved to roundstart spawn in
     EmergencyRollerBedSpawnFolded: 1
     BoxBodyBag: 1
     # Extra Expendable Gear
@@ -48,6 +48,7 @@
     # Optional / Situational Gear
     BoxBottle: 3
     Defibrillator: 2 # Easily shared between several people
+    ChemistryBottleEpinephrine: 3 #KS14, why the FUCK was it not on the nanomed +
     Syringe: 4
     PillCanisterTricordrazine: 4
     ClothingOuterHospitalGown: 2 # Not a popular item, so less stock

--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -184,6 +184,7 @@
       - DiscreteHealthAnalyzer
       - SurgeryTool
       - Dropper
+      - GlassBeaker #ks14
       components:
       - Injector
       - Pill

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: handheld crew monitor
   categories: [ DoNotMap ]
-  parent: [ BaseHandheldComputer, BaseGrandTheftContraband ]
+  parent: BaseHandheldComputer #, BaseGrandTheftContraband ] KS14
   # CMO-only bud, don't add more.
   id: HandheldCrewMonitor
   description: A hand-held crew monitor displaying the status of suit sensors.
@@ -26,11 +26,11 @@
   - type: StationLimitedNetwork
   - type: StaticPrice
     price: 500
-  - type: Tag
-    tags:
-    - HighRiskItem
-  - type: StealTarget
-    stealGroup: HandheldCrewMonitor
+#  - type: Tag KS14 start
+#    tags:
+#    - HighRiskItem
+#  - type: StealTarget
+#    stealGroup: HandheldCrewMonitor KS14 end
   - type: EmitSoundOnPickup # KS14: pickup/drop sounds
     sound:
       path: /Audio/_KS14/Handling/component_pickup.ogg

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -7,12 +7,13 @@
     sprite: Objects/Specific/Medical/hypospray.rsi
     state: hypo
 
-- type: stealTargetGroup
-  id: HandheldCrewMonitor
-  name: steal-target-groups-handheld-crew-monitor
-  sprite:
-    sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi
-    state: scanner
+# KLOVN
+#- type: stealTargetGroup
+#  id: HandheldCrewMonitor
+#  name: steal-target-groups-handheld-crew-monitor
+#  sprite:
+#    sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi
+#    state: scanner
 
 - type: stealTargetGroup
   id: ClothingOuterHardsuitRd

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -205,12 +205,13 @@
   - type: StealCondition
     stealGroup: Hypospray
 
-- type: entity
-  parent: BaseCMOStealObjective
-  id: CMOCrewMonitorStealObjective
-  components:
-  - type: StealCondition
-    stealGroup: HandheldCrewMonitor
+# KLOVN
+#- type: entity
+#  parent: BaseCMOStealObjective
+#  id: CMOCrewMonitorStealObjective
+#  components:
+#  - type: StealCondition
+#    stealGroup: HandheldCrewMonitor
 
 ## rd
 

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -154,7 +154,7 @@
         conditions:
         - !type:ReagentCondition
           reagent: Bicaridine
-          min: 15
+          min: 20 #Ks14 change, i love slop
         damage:
           types:
             Asphyxiation: 0.5
@@ -241,7 +241,7 @@
         conditions:
         - !type:ReagentCondition
           reagent: Dermaline
-          min: 10
+          min: 20 #ks14 change
         damage:
           types:
             Asphyxiation: 1

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -55,3 +55,4 @@
     neck: ClothingCloakCmo
     outerClothing: ClothingOuterCoatLabCmo
     gloves: ClothingHandsGlovesNitrile
+    belt: ClothingBeltMedicalFilled #KS14

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -35,3 +35,4 @@
     neck: ClothingNeckStethoscope
     outerClothing: ClothingOuterCoatLab
     gloves: ClothingHandsGlovesLatex
+    belt: ClothingBeltMedicalFilled #KS14

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -32,3 +32,4 @@
     neck: ClothingNeckStethoscope
     outerClothing: ClothingOuterCoatParamedicWB
     gloves: ClothingHandsGlovesLatex
+    belt: ClothingBeltMedicalEMTFilled #KS14


### PR DESCRIPTION
## What was changed
CL

## Why
makes sense

## Media
see yaml

## Requirements
- [ ] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] Design doc


**Changelog**
:cl:
- add: Epinephrine bottles to nanomed plus
- tweak: Iron pills to first aid kids, another bruise pack to brute kits
- tweak: Moved filled medical belts to loadout (You spawn in with it)
- tweak: Paramed belt fill now useful
- tweak: Paramed gets a handheld crew monitor, which is no longer a steal objective
- tweak: Tweaked medical doctor locker fill
- tweak: Medbelts can store beakers
- tweak: Dermaline and Bic now both od at 20u
