### PR TITLE
fixer

### DIFF
--- a/Content.Server/Materials/OreSiloSystem.cs
+++ b/Content.Server/Materials/OreSiloSystem.cs
@@ -31,7 +31,7 @@ public sealed class OreSiloSystem : SharedOreSiloSystem
         var xform = Transform(ent);
 
         // Sneakily uses override with TComponent parameter
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, ent.Comp.Range, _clientLookup);
+        _entityLookup.GetEntitiesOnMap(xform.MapID, _clientLookup);
 
         foreach (var client in _clientLookup)
         {

--- a/Content.Server/Research/Systems/ResearchSystem.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.cs
@@ -80,11 +80,9 @@ namespace Content.Server.Research.Systems
         public HashSet<Entity<ResearchServerComponent>> GetServers(EntityUid client)
         {
             var clientXform = Transform(client);
-            if (clientXform.GridUid is not { } grid)
-                return [];
 
             var set = new HashSet<Entity<ResearchServerComponent>>();
-            _lookup.GetGridEntities(grid, set);
+            _lookup.GetEntitiesOnMap(clientXform.MapID, set);
             return set;
         }
 

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -305,22 +305,6 @@ public sealed partial class DoorComponent : Component
     [DataField]
     public bool? ForcedCollisionCheckOnClick = null;
 
-    // KS14
-    /// <summary>
-    ///     Bodypart types that may be hit when crushing something.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField]
-    public _KS14.Klovnmed.BodyPartType? CrushableBodyPartType = null;
-
-    // KS14
-    /// <summary>
-    ///     Minimum total damage before bodyparts can be dismembered.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField]
-    public float CrushDelimbDamageThreshold = 0f;
-
     [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int OpenDrawDepth = (int)DrawDepth.DrawDepth.Doors;
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -46,7 +46,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly SharedPowerReceiverSystem _powerReceiver = default!;
-    [Dependency] private readonly _KS14.Klovnmed.Dismemberment.DismembermentSystem _dismembermentSystem = default!; // KS14: Crush dismemberment
 
     public static readonly ProtoId<TagPrototype> DoorBumpTag = "DoorBumpOpener";
 
@@ -534,16 +533,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
             door.CurrentlyCrushing.Add(entity);
             if (door.CrushDamage != null)
                 _damageableSystem.TryChangeDamage(entity, door.CrushDamage, origin: uid);
-
-            // KS14: Crush dismemberment start
-            if (door.CrushableBodyPartType is { } crushableType &&
-                _damageableSystem.GetTotalDamage(entity) >= door.CrushDelimbDamageThreshold &&
-                _dismembermentSystem.TryDismemberRandomBodyPartOfType(entity, crushableType, out var partUid, cause: uid))
-            {
-                _dismembermentSystem.DoFixedEmote(entity);
-                _dismembermentSystem.TryRandomlyCrushPart(partUid.Value, victimUid: entity, predicted: false);
-            }
-            // KS14: Crush dismemberment end
 
             _stunSystem.TryUpdateParalyzeDuration(entity, stunTime);
         }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -35,11 +35,8 @@ public abstract partial class SharedHandsSystem
         var freeHands = CountFreeHands(ent.AsNullable());
         var totalHands = GetHandCount(ent.AsNullable());
 
-        // Can't crawl around without any hands.
-        // Entities without the HandsComponent will always have full crawling speed.
+        // KS14: double hand slowdown sux
         if (totalHands == 0)
-            args.SpeedModifier = 0f;
-        else
-            args.SpeedModifier *= (float)freeHands / totalHands;
+            args.SpeedModifier *= (float)freeHands / totalHands / 2f;
     }
 }

--- a/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
+++ b/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
@@ -21,9 +21,10 @@ public sealed partial class OreSiloComponent : Component
     /// </summary>
     /// <remarks>
     /// Default value should be big enough to span a single large department.
+    /// KS14: removed since we check map anyway
     /// </remarks>
-    [DataField, AutoNetworkedField]
-    public float Range = 20f;
+    // [DataField, AutoNetworkedField]
+    // public float Range = 20f;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
+++ b/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
@@ -157,10 +157,7 @@ public abstract class SharedOreSiloSystem : EntitySystem
         if (!_powerReceiver.IsPowered(silo.Owner))
             return false;
 
-        if (_transform.GetGrid(client) != _transform.GetGrid(silo.Owner))
-            return false;
-
-        if (!_transform.InRange((silo.Owner, silo.Comp2), client, silo.Comp1.Range))
+        if (_transform.GetMap(client) != _transform.GetMap(silo.Owner))
             return false;
 
         return true;

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -68,7 +68,7 @@
   - type: Door
     crushDamage:
       types:
-        Blunt: 50
+        Blunt: 25 # thumbsup
     openSound:
       path: /Audio/Machines/airlock_open.ogg
     closeSound:

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -100,8 +100,6 @@
       # KS14 start
       performCollisionCheck: false
       forcedCollisionCheckOnClick: true
-      crushableBodyPartType: [ Arm, Leg, Hand ]
-      crushDelimbDamageThreshold: 90
       # KS14 end
       openDrawDepth: WallTops
       closeTimeOne: 0.1
@@ -113,7 +111,7 @@
       clickOpen: true
       crushDamage:
         types:
-          Blunt: 35 # KS14: 15 -> 35
+          Blunt: 15
       openSound:
         path: /Audio/Machines/airlock_open.ogg
       closeSound:

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -55,7 +55,7 @@
     closingAnimationTime: 1.4
     crushDamage:
       types:
-        Blunt: 5 # getting shutters closed on you probably doesn't hurt that much
+        Blunt: 15 # KS14: thumbsup
     openSound:
       path: /Audio/Machines/shutter.ogg
     closeSound:


### PR DESCRIPTION
## What was changed
<!-- If changelog sufficiently describes your changes, you may omit this section -->
firelocks now only do 15 dmg and not delimb
rnd server and ore silo now check for map instead of grid
ore silo has inf range now
fixed movement speed with occupied hands while crawling
## Why
noone likes firelock delimb
## Media

## Requirements
- [x] Tested, works.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] Design doc

## Breaking changes
<!-- List any changes that might break future work -->

**Changelog**
:cl: DecemberEpsilon
- tweak: No more firelock delimb
- tweak: Movement buffs when crawling
