### PR TITLE
saltern fix, ai buffs, lava changes

### DIFF
--- a/Content.Client/_KS14/Lava/KsLavaSinkingSystem.cs
+++ b/Content.Client/_KS14/Lava/KsLavaSinkingSystem.cs
@@ -15,13 +15,10 @@ public sealed class KsLavaSinkingSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     private static readonly ProtoId<ShaderPrototype> ShaderId = "HorizontalCut";
-    private ShaderInstance _shaderInstance = null!;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _shaderInstance = _prototypeManager.Index(ShaderId).InstanceUnique();
 
         SubscribeLocalEvent<KsLavaSinkingComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<KsLavaSinkingComponent, ComponentShutdown>(OnShutdown);
@@ -44,7 +41,8 @@ public sealed class KsLavaSinkingSystem : EntitySystem
         if (!TryComp<SpriteComponent>(entity.Owner, out var spriteComponent))
             return;
 
-        spriteComponent.PostShader = enabled ? _shaderInstance : null;
+        entity.Comp.Shader = enabled ? _prototypeManager.Index(ShaderId).InstanceUnique() : null;
+        spriteComponent.PostShader = (ShaderInstance?)entity.Comp.Shader;
         spriteComponent.RaiseShaderEvent = enabled;
     }
 
@@ -53,7 +51,8 @@ public sealed class KsLavaSinkingSystem : EntitySystem
         var time = (float)((entity.Comp.SinkTime - _gameTiming.CurTime) / (entity.Comp.SinkTime - entity.Comp.StartTime));
         time = MathF.Max(time, 0f);
 
-        _shaderInstance.SetParameter("c", 1 - time);
-        _shaderInstance.SetParameter("alphaModifier", MathF.Max(time - 0.25f, 0f));
+        var shaderInstance = (ShaderInstance)entity.Comp.Shader!;
+        shaderInstance.SetParameter("c", 1 - time);
+        shaderInstance.SetParameter("alphaModifier", MathF.Max(time - 0.25f, 0f));
     }
 }

--- a/Content.Client/_KS14/Lava/KsLavaSinkingSystem.cs
+++ b/Content.Client/_KS14/Lava/KsLavaSinkingSystem.cs
@@ -1,0 +1,59 @@
+using Content.Shared._KS14.Lava;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Client._KS14.Lava;
+
+/// <summary>
+///     Not my proudest code yet
+/// </summary>
+public sealed class KsLavaSinkingSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    private static readonly ProtoId<ShaderPrototype> ShaderId = "HorizontalCut";
+    private ShaderInstance _shaderInstance = null!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _shaderInstance = _prototypeManager.Index(ShaderId).InstanceUnique();
+
+        SubscribeLocalEvent<KsLavaSinkingComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<KsLavaSinkingComponent, ComponentShutdown>(OnShutdown);
+
+        SubscribeLocalEvent<KsLavaSinkingComponent, BeforePostShaderRenderEvent>(OnShaderRender);
+    }
+
+    private void OnStartup(Entity<KsLavaSinkingComponent> entity, ref ComponentStartup args)
+    {
+        SetShaderEnabled(entity, true);
+    }
+
+    private void OnShutdown(Entity<KsLavaSinkingComponent> entity, ref ComponentShutdown args)
+    {
+        SetShaderEnabled(entity, false);
+    }
+
+    private void SetShaderEnabled(Entity<KsLavaSinkingComponent> entity, bool enabled)
+    {
+        if (!TryComp<SpriteComponent>(entity.Owner, out var spriteComponent))
+            return;
+
+        spriteComponent.PostShader = enabled ? _shaderInstance : null;
+        spriteComponent.RaiseShaderEvent = enabled;
+    }
+
+    private void OnShaderRender(Entity<KsLavaSinkingComponent> entity, ref BeforePostShaderRenderEvent args)
+    {
+        var time = (float)((entity.Comp.SinkTime - _gameTiming.CurTime) / (entity.Comp.SinkTime - entity.Comp.StartTime));
+        time = MathF.Max(time, 0f);
+
+        _shaderInstance.SetParameter("c", 1 - time);
+        _shaderInstance.SetParameter("alphaModifier", MathF.Max(time - 0.25f, 0f));
+    }
+}

--- a/Content.Server/_KS14/NPC/Components/NpcDisturbOnTriggerComponent.cs
+++ b/Content.Server/_KS14/NPC/Components/NpcDisturbOnTriggerComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Trigger.Components.Triggers;
+
+namespace Content.Server._KS14.NPC.Components;
+
+/// <summary>
+///     Disturbs nearby NPCs upon trigger.
+/// </summary>
+[RegisterComponent]
+public sealed partial class NpcDisturbOnTriggerComponent : BaseTriggerOnXComponent
+{
+    [DataField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float Radius = 3f;
+
+    [DataField]
+    public bool TargetUser = false;
+}

--- a/Content.Server/_KS14/NPC/Queries/Considerations/CoordinatesInFOVCon.cs
+++ b/Content.Server/_KS14/NPC/Queries/Considerations/CoordinatesInFOVCon.cs
@@ -33,9 +33,9 @@ public sealed partial class CoordinatesInFOVCon : UtilityConsideration
         if (!blackboard.TryGetValue<EntityCoordinates>(ReferenceCoordinatesKey, out var referenceCoordinates, EntityManager))
             return 0f;
 
-        var ownerPosition = _transformSystem.GetMapCoordinates(ownerUid).Position;
-        var targetPosition = _transformSystem.GetMapCoordinates(targetUid).Position;
-        var referencePosition = _transformSystem.ToMapCoordinates(referenceCoordinates).Position;
+        var ownerPosition = _transformSystem.GetWorldPosition(ownerUid);
+        var targetPosition = _transformSystem.GetWorldPosition(targetUid);
+        var referencePosition = _transformSystem.ToWorldPosition(referenceCoordinates);
 
         var forward = targetPosition - ownerPosition;
         Vector2Helpers.Normalize(ref forward);

--- a/Content.Server/_KS14/NPC/Queries/Considerations/CoordinatesInFOVCon.cs
+++ b/Content.Server/_KS14/NPC/Queries/Considerations/CoordinatesInFOVCon.cs
@@ -1,0 +1,53 @@
+using System.Numerics;
+using Content.Server.NPC;
+using Content.Server.NPC.Queries.Considerations;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.Server._KS14.NPC.Queries.Considerations;
+
+/// <summary>
+///     Assumes a field of view starting from the owner
+///         and pointed in the direction of the reference coordinates.
+///
+///     For targets that are in this FOV (given <see cref="Angle"/>),
+///         returns 1f. Otherwise, returns 0f.
+/// </summary>
+public sealed partial class CoordinatesInFOVCon : UtilityConsideration
+{
+    [Dependency] private readonly TransformSystem _transformSystem = default!;
+
+    /// <summary>
+    ///     Second set of coordinates, compared with owner coordinates, to determine
+    ///         the direction of the FOV.
+    /// </summary>
+    [DataField("toKey", required: true)] public string ReferenceCoordinatesKey = default!;
+
+    /// <summary>
+    ///     Permitting angle, in degrees.
+    /// </summary>
+    [DataField(required: true)] public float Angle;
+
+    public override float GetScore(NPCBlackboard blackboard, EntityUid ownerUid, EntityUid targetUid)
+    {
+        if (!blackboard.TryGetValue<EntityCoordinates>(ReferenceCoordinatesKey, out var referenceCoordinates, EntityManager))
+            return 0f;
+
+        var ownerPosition = _transformSystem.GetMapCoordinates(ownerUid).Position;
+        var targetPosition = _transformSystem.GetMapCoordinates(targetUid).Position;
+        var referencePosition = _transformSystem.ToMapCoordinates(referenceCoordinates).Position;
+
+        var forward = targetPosition - ownerPosition;
+        Vector2Helpers.Normalize(ref forward);
+
+        var toTarget = referencePosition - ownerPosition;
+        Vector2Helpers.Normalize(ref toTarget);
+
+        var dot = Vector2.Dot(forward, toTarget);
+
+        var halfFovRad = MathF.PI * (Angle / 2f) / 180f;
+        var threshold = MathF.Cos(halfFovRad);
+
+        return dot >= threshold ? 1f : 0f;
+    }
+}

--- a/Content.Server/_KS14/NPC/Systems/NpcSensorSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcSensorSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server._KS14.NPC.Components;
 using Content.Shared._KS14.NPC.Systems;
+using Content.Shared.Trigger;
 using Robust.Shared.Map;
 
 namespace Content.Server._KS14.NPC.Systems;
@@ -11,6 +12,29 @@ public sealed class NpcSensorSystem : SharedNpcSensorSystem
     [Dependency] private readonly EntityQuery<NpcSensorsComponent> _sensorsQuery = default!;
 
     private const string DisturbanceCoordinatesSensorKey = "__Sensor__Disturbance.TargetCoordinates";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NpcDisturbOnTriggerComponent, TriggerEvent>(OnTrigger);
+    }
+
+    private void OnTrigger(Entity<NpcDisturbOnTriggerComponent> entity, ref TriggerEvent args)
+    {
+        EntityCoordinates coordinates;
+        if (entity.Comp.TargetUser)
+        {
+            if (args.User is not { } userUid)
+                return;
+
+            coordinates = Transform(userUid).Coordinates;
+        }
+        else
+            coordinates = Transform(entity.Owner).Coordinates;
+
+        DoDisturbance(coordinates, entity.Comp.Radius);
+    }
 
     public void AddEffect(Entity<NpcSensorsComponent?> entity, string key, object? value)
     {

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -202,7 +202,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
 
         // KS14 Addition: effects
         if (args.Origin is { } originUid)
-            _bloodSpraySystem.HandleBleedEffects(ent!, args.DamageDelta, originUid);
+            _bloodSpraySystem.HandleBleedEffects(ent!, bloodloss, originUid);
 
         // Critical hit. Causes target to lose blood, using the bleed rate modifier of the weapon, currently divided by 5
         // The crit chance is currently the bleed rate modifier divided by 25.

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -202,7 +202,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
 
         // KS14 Addition: effects
         if (args.Origin is { } originUid)
-            _bloodSpraySystem.HandleBleedEffects(ent!, totalFloat * 5f, originUid);
+            _bloodSpraySystem.HandleBleedEffects(ent!, totalFloat * 2f, originUid);
 
         // Critical hit. Causes target to lose blood, using the bleed rate modifier of the weapon, currently divided by 5
         // The crit chance is currently the bleed rate modifier divided by 25.

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -202,7 +202,7 @@ public abstract class SharedBloodstreamSystem : EntitySystem
 
         // KS14 Addition: effects
         if (args.Origin is { } originUid)
-            _bloodSpraySystem.HandleBleedEffects(ent!, bloodloss, originUid);
+            _bloodSpraySystem.HandleBleedEffects(ent!, totalFloat * 5f, originUid);
 
         // Critical hit. Causes target to lose blood, using the bleed rate modifier of the weapon, currently divided by 5
         // The crit chance is currently the bleed rate modifier divided by 25.

--- a/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Gravity;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems; // KS14
+using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
@@ -79,23 +80,6 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
 
         RemCompDeferred<ActiveLeaperComponent>(entity);
     }
-
-    /*
-    punished = true;
-    knocked = false;
-
-    if (punished || knocked)
-        punished = true
-        => punished = true
-
-    if (punished(true) || !knocked(!false => true))
-        punished = true
-        => punished = true
-
-    if (punished(true) || knocked(true))
-        punished = false
-        => punished = true
-    */
 
     private void OnLeaperLand(Entity<ActiveLeaperComponent> entity, ref LandEvent args)
     {

--- a/Content.Shared/_KS14/EntityProcessor/KsEntityProcessorComponent.cs
+++ b/Content.Shared/_KS14/EntityProcessor/KsEntityProcessorComponent.cs
@@ -44,16 +44,26 @@ public sealed partial class KsEntityProcessorComponent : Component
 public record struct KsAttemptProcessEntityEvent(bool Cancelled, Entity<KsEntityProcessorComponent> ProcessorEntity, EntityUid ProcessedUid, TimeSpan ProcessingFinishTime);
 
 /// <summary>
-///     Raised on a processor when an entity is done being processed.
+///     Raised on a processor when an entity starts being processed, before
+///         it is forced into the processor container.
 /// </summary>
 [ByRefEvent]
-public record struct KsStartedProcessingEntityEvent(Entity<KsEntityProcessorComponent> ProcessorEntity, EntityUid ProcessedUid);
+public record struct KsStartedProcessingEntityEvent(Entity<KsEntityProcessorComponent, TransformComponent> ProcessorEntity, EntityUid ProcessedUid);
 
 /// <summary>
 ///     Raised on a processor when an entity is done being processed.
 /// </summary>
 [ByRefEvent]
 public record struct KsFinishedProcessingEntityEvent(Entity<KsEntityProcessorComponent, KsActiveEntityProcessorComponent?> Entity, EntityUid ProcessedUid);
+
+/// <summary>
+///     Raised on an active processor after an entity is removed from the processor container;
+///         can be either on successful processing or fail.
+///
+///     Not automatically raised by base processor code when something has <i>finished</i> processing.
+/// </summary>
+[ByRefEvent]
+public record struct KsEntityRemovedFromActiveProcessorEvent(Entity<KsActiveEntityProcessorComponent> Entity, EntityUid ProcessedUid);
 
 /// <summary>
 ///     Raised on a processor when there is nothing left to process.

--- a/Content.Shared/_KS14/EntityProcessor/KsEntityProcessorSystem.cs
+++ b/Content.Shared/_KS14/EntityProcessor/KsEntityProcessorSystem.cs
@@ -87,13 +87,21 @@ public sealed class KsEntityProcessorSystem : EntitySystem
         var attemptEv = new KsAttemptProcessEntityEvent(false, processorEntity!, processedEntity, _gameTiming.CurTime);
         RaiseLocalEvent(processorEntity, ref attemptEv);
 
-        if (attemptEv.Cancelled)
+        var processorTransformComponent = Transform(processorEntity.Owner);
+
+        if (attemptEv.Cancelled ||
+            !_containerSystem.CanInsert(processedEntity.Owner, processorEntity.Comp.Container, containerXform: processorTransformComponent))
             return false;
 
-        _containerSystem.Insert((processedEntity, null, null, processedEntity), processorEntity.Comp.Container);
-
-        var startEv = new KsStartedProcessingEntityEvent(processorEntity!, processedEntity);
+        var startEv = new KsStartedProcessingEntityEvent((processorEntity.Owner, processorEntity.Comp, processorTransformComponent), processedEntity);
         RaiseLocalEvent(processorEntity, ref startEv);
+
+        _containerSystem.Insert(
+            (processedEntity, null, null, processedEntity),
+            processorEntity.Comp.Container,
+            containerXform: processorTransformComponent,
+            force: true /* already checked Caninsert */
+        );
 
         if (attemptEv.ProcessingFinishTime == _gameTiming.CurTime)
         {
@@ -126,6 +134,9 @@ public sealed class KsEntityProcessorSystem : EntitySystem
 
         entity.Comp.Processing.Remove(entity);
         Dirty(entity);
+
+        var ev = new KsEntityRemovedFromActiveProcessorEvent(entity, args.Entity);
+        RaiseLocalEvent(entity.Owner, ref ev);
     }
 
     private void OnPowerChanged(Entity<KsEntityProcessorComponent> entity, ref PowerChangedEvent args)

--- a/Content.Shared/_KS14/EntityProcessor/StackProcessor/KsStackProcessorComponent.cs
+++ b/Content.Shared/_KS14/EntityProcessor/StackProcessor/KsStackProcessorComponent.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Stacks;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -6,6 +7,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._KS14.EntityProcessor.StackProcessor;
 
 [RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
 [Access(typeof(KsStackProcessorSystem))]
 public sealed partial class KsStackProcessorComponent : Component
 {
@@ -27,6 +29,13 @@ public sealed partial class KsStackProcessorComponent : Component
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
     public Dictionary<ProtoId<StackPrototype>, EntProtoId> Conversions = [];
+
+    /// <summary>
+    ///     Dict of things that are being processed, and where they will be outputted relative to the processor.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<EntityUid, Vector2> OutputOffsets = [];
 
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/_KS14/EntityProcessor/StackProcessor/KsStackProcessorSystem.cs
+++ b/Content.Shared/_KS14/EntityProcessor/StackProcessor/KsStackProcessorSystem.cs
@@ -17,22 +17,11 @@ public sealed class KsStackProcessorSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<KsStackProcessorComponent, PreventCollideEvent>(OnPreventCollide);
-
         SubscribeLocalEvent<KsStackProcessorComponent, KsAttemptProcessEntityEvent>(OnAttemptProcess);
         SubscribeLocalEvent<KsStackProcessorComponent, KsStartedProcessingEntityEvent>(OnStartedProcessing);
         SubscribeLocalEvent<KsStackProcessorComponent, KsFinishedProcessingEntityEvent>(OnFinishedProcessing);
+        SubscribeLocalEvent<KsStackProcessorComponent, KsEntityRemovedFromActiveProcessorEvent>(OnEntityRemovedFromProcessor);
         SubscribeLocalEvent<KsStackProcessorComponent, KsFinishedProcessingEverythingEvent>(OnFinishedProcessingEverything);
-    }
-
-    private void OnPreventCollide(Entity<KsStackProcessorComponent> entity, ref PreventCollideEvent args)
-    {
-        if (args.Cancelled)
-            return;
-
-        if (!TryComp<StackComponent>(args.OtherEntity, out var stackComponent) ||
-            !entity.Comp.Conversions.ContainsKey(stackComponent.StackTypeId))
-            args.Cancelled = true;
     }
 
     private void OnAttemptProcess(Entity<KsStackProcessorComponent> entity, ref KsAttemptProcessEntityEvent args)
@@ -53,6 +42,10 @@ public sealed class KsStackProcessorSystem : EntitySystem
     private void OnStartedProcessing(Entity<KsStackProcessorComponent> entity, ref KsStartedProcessingEntityEvent args)
     {
         _appearanceSystem.SetData(entity.Owner, KsStackProcessorVisuals.Active, true);
+
+        var delta = _transformSystem.GetWorldPosition(args.ProcessedUid) - _transformSystem.GetWorldPosition(args.ProcessorEntity.Comp2);
+        entity.Comp.OutputOffsets[args.ProcessedUid] = -delta;
+        Dirty(entity);
     }
 
     private void OnFinishedProcessing(Entity<KsStackProcessorComponent> entity, ref KsFinishedProcessingEntityEvent args)
@@ -72,6 +65,7 @@ public sealed class KsStackProcessorSystem : EntitySystem
         var maxCount = _prototypeManager.Index(stackComponent.StackTypeId).MaxCount ?? int.MaxValue;
 
         var spawnCoordinates = _transformSystem.GetMoverCoordinates(entity.Owner);
+        spawnCoordinates = spawnCoordinates.WithPosition(spawnCoordinates.Position + entity.Comp.OutputOffsets[args.ProcessedUid]);
 
         if (spawnedCount <= maxCount)
         {
@@ -87,6 +81,14 @@ public sealed class KsStackProcessorSystem : EntitySystem
 
             _stackSystem.SetCount((PredictedSpawnAtPosition(convertedProto, spawnCoordinates), null), spawnedCount % maxCount);
         }
+    }
+
+    private void OnEntityRemovedFromProcessor(Entity<KsStackProcessorComponent> entity, ref KsEntityRemovedFromActiveProcessorEvent args)
+    {
+        if (!entity.Comp.OutputOffsets.Remove(args.ProcessedUid))
+            return;
+
+        Dirty(entity);
     }
 
     private void OnFinishedProcessingEverything(Entity<KsStackProcessorComponent> entity, ref KsFinishedProcessingEverythingEvent args)

--- a/Content.Shared/_KS14/Lava/KsLavaComponent.cs
+++ b/Content.Shared/_KS14/Lava/KsLavaComponent.cs
@@ -11,11 +11,9 @@ namespace Content.Shared._KS14.Lava;
 [Access(typeof(KsLavaSystem))]
 public sealed partial class KsLavaComponent : Component
 {
-    [DataField]
     [AutoNetworkedField]
     public EntityUid? LocalGridUid = null;
 
-    [DataField]
     [AutoNetworkedField]
     public Vector2i LocalTile = Vector2i.Zero;
 

--- a/Content.Shared/_KS14/Lava/KsLavaComponent.cs
+++ b/Content.Shared/_KS14/Lava/KsLavaComponent.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Damage;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._KS14.Lava;
+
+/// <summary>
+///     Oops, all hardcoded.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+[Access(typeof(KsLavaSystem))]
+public sealed partial class KsLavaComponent : Component
+{
+    [DataField]
+    [AutoNetworkedField]
+    public EntityUid? LocalGridUid = null;
+
+    [DataField]
+    [AutoNetworkedField]
+    public Vector2i LocalTile = Vector2i.Zero;
+
+    [DataField(required: true)]
+    public DamageSpecifier Damage = null!;
+
+    [DataField]
+    public TimeSpan KnockdownDuration = TimeSpan.Zero;
+
+    [DataField]
+    public TimeSpan SinkDuration = TimeSpan.FromSeconds(0.5f);
+}

--- a/Content.Shared/_KS14/Lava/KsLavaSinkingComponent.cs
+++ b/Content.Shared/_KS14/Lava/KsLavaSinkingComponent.cs
@@ -7,7 +7,6 @@ namespace Content.Shared._KS14.Lava;
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState, AutoGenerateComponentPause]
-[Access(typeof(KsLavaSystem))]
 public sealed partial class KsLavaSinkingComponent : Component
 {
     /// <summary>
@@ -23,4 +22,6 @@ public sealed partial class KsLavaSinkingComponent : Component
     [DataField, AutoNetworkedField]
     [AutoPausedField]
     public TimeSpan SinkTime = TimeSpan.MinValue;
+
+    public object? Shader = null;
 }

--- a/Content.Shared/_KS14/Lava/KsLavaSinkingComponent.cs
+++ b/Content.Shared/_KS14/Lava/KsLavaSinkingComponent.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._KS14.Lava;
+
+/// <summary>
+///     Added to things that are sinking in lava.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(KsLavaSystem))]
+public sealed partial class KsLavaSinkingComponent : Component
+{
+    /// <summary>
+    ///     Game-time at which this started sinking.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    [AutoPausedField]
+    public TimeSpan StartTime = TimeSpan.MinValue;
+
+    /// <summary>
+    ///     Game-time at which this will be finished sinking.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    [AutoPausedField]
+    public TimeSpan SinkTime = TimeSpan.MinValue;
+}

--- a/Content.Shared/_KS14/Lava/KsLavaSystem.cs
+++ b/Content.Shared/_KS14/Lava/KsLavaSystem.cs
@@ -1,0 +1,132 @@
+using Content.Shared.Chat;
+using Content.Shared.Damage.Systems;
+using Content.Shared.GameTicking;
+using Content.Shared.StepTrigger.Systems;
+using Content.Shared.Stunnable;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._KS14.Lava;
+
+/// <summary>
+///     Not my proudest code yet
+/// </summary>
+public sealed class KsLavaSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+    [Dependency] private readonly SharedStunSystem _stunSystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
+    [Dependency] private readonly SharedChatSystem _chatSystem = default!;
+
+    /// <summary>
+    ///     List of occupied lava tiles on each grid or whatever.
+    /// </summary>
+    private readonly Dictionary<EntityUid, HashSet<Vector2i>> _lavaMap = [];
+
+    // tbh if i really tryharded, this wouldnt be necessary either
+    private static readonly Vector2i[] ValidDirections = [Vector2i.Up, Vector2i.UpLeft, Vector2i.UpRight, Vector2i.Left, Vector2i.Right, Vector2i.Down, Vector2i.DownLeft, Vector2i.DownRight];
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<KsLavaComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
+        SubscribeLocalEvent<KsLavaComponent, StepTriggeredOffEvent>(OnStepTriggered);
+
+        SubscribeLocalEvent<KsLavaComponent, EntParentChangedMessage>(OnEntParentChanged);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>((_) => _lavaMap.Clear());
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var sinkingEqe = EntityQueryEnumerator<KsLavaSinkingComponent>();
+        while (sinkingEqe.MoveNext(out var uid, out var sinkingComponent))
+        {
+            if (_gameTiming.CurTime < sinkingComponent.SinkTime)
+                continue;
+
+            PredictedQueueDel(uid);
+        }
+    }
+
+    private void OnStepTriggerAttempt(Entity<KsLavaComponent> entity, ref StepTriggerAttemptEvent args)
+    {
+        args.Continue = true;
+    }
+
+    private void OnStepTriggered(Entity<KsLavaComponent> entity, ref StepTriggeredOffEvent args)
+    {
+        if (!_damageableSystem.TryChangeDamage(args.Tripper, entity.Comp.Damage, origin: entity.Owner))
+            return;
+
+        _stunSystem.TryKnockdown(args.Tripper, entity.Comp.KnockdownDuration, refresh: true, autoStand: false);
+
+        // If surrounded totally by lava, ash them
+        if (HasComp<KsLavaSinkingComponent>(args.Tripper) ||
+            !IsSurrounded(entity))
+            return;
+
+        var sinkingComponent = AddComp<KsLavaSinkingComponent>(args.Tripper);
+        sinkingComponent.StartTime = _gameTiming.CurTime;
+        sinkingComponent.SinkTime = _gameTiming.CurTime + entity.Comp.SinkDuration;
+        Dirty(args.Tripper, sinkingComponent);
+
+        _physicsSystem.SetBodyType(args.Tripper, BodyType.Static);
+        _chatSystem.TryEmoteWithChat(args.Tripper, "Scream"); // yes i know
+    }
+
+    private void OnEntParentChanged(Entity<KsLavaComponent> entity, ref EntParentChangedMessage args)
+    {
+        var transformComponent = args.Transform;
+        var newGridUid = transformComponent.GridUid;
+
+        if (entity.Comp.LocalGridUid is { } oldGridUid &&
+            newGridUid != oldGridUid &&
+            _lavaMap.TryGetValue(oldGridUid, out var oldLocalMap))
+        {
+            oldLocalMap.Remove(entity.Comp.LocalTile);
+
+            entity.Comp.LocalGridUid = null;
+            Dirty(entity);
+
+            if (oldLocalMap.Count == 0)
+                _lavaMap.Remove(oldGridUid);
+        }
+
+        if (_transformSystem.TryGetGridTilePosition((entity.Owner, transformComponent), out var tilePos))
+        {
+            var localMap = _lavaMap.GetOrNew(newGridUid!.Value);
+            if (!localMap.Add(tilePos))
+                return;
+
+            entity.Comp.LocalGridUid = newGridUid;
+            entity.Comp.LocalTile = tilePos;
+            Dirty(entity);
+        }
+    }
+
+    /// <returns>True if the lava is surrounded on all sides by more lava, false otherwise (when the lava is an edge).</returns>
+    public bool IsSurrounded(Entity<KsLavaComponent> entity)
+    {
+        if (entity.Comp.LocalGridUid is not { } gridUid ||
+            !_lavaMap.TryGetValue(gridUid, out var localMap))
+            return false;
+
+        foreach (var direction in ValidDirections)
+        {
+            if (localMap.Contains(entity.Comp.LocalTile + direction))
+                continue;
+
+            // End early and return false, as this direction is empty
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/_KS14/Lava/KsLavaSystem.cs
+++ b/Content.Shared/_KS14/Lava/KsLavaSystem.cs
@@ -3,8 +3,10 @@ using Content.Shared.Damage.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Stunnable;
+using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -16,6 +18,8 @@ namespace Content.Shared._KS14.Lava;
 public sealed class KsLavaSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly INetManager _netManager = default!;
+    [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly SharedStunSystem _stunSystem = default!;
@@ -78,7 +82,15 @@ public sealed class KsLavaSystem : EntitySystem
         Dirty(args.Tripper, sinkingComponent);
 
         _physicsSystem.SetBodyType(args.Tripper, BodyType.Static);
-        _chatSystem.TryEmoteWithChat(args.Tripper, "Scream"); // yes i know
+        _transformSystem.SetCoordinates(args.Tripper, Transform(entity.Owner).Coordinates);
+
+        if (!_netManager.IsServer)
+            return;
+
+        if (_robustRandom.Prob(0.02f))
+            _chatSystem.TrySendInGameICMessage(args.Tripper, "gives a thumbs up as they melt to death…", InGameICChatType.Emote, false); // i wonder what this is in reference to
+        else
+            _chatSystem.TryEmoteWithChat(args.Tripper, "Scream"); // yes i know
     }
 
     private void OnEntParentChanged(Entity<KsLavaComponent> entity, ref EntParentChangedMessage args)

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -37778,12 +37778,11 @@ entities:
       - !type:BiomeEntityLayer
         threshold: -0.3
         noise:
-          frequency: 0.05
-          noiseType: Cellular
-          fractalType: FBm
-          octaves: 5
-          cellularDistanceFunction: Euclidean
-          cellularReturnType: Distance2
+          frequency: 0.2
+          noiseType: Perlin
+          fractalType: Ridged
+          gain: 0.5
+          octaves: 3
           seed: 0
         allowedTiles:
         - FloorSnow

--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -37,9 +37,10 @@
     - map: [ "shoes" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
-    - map: [ "belt" ]
+    # KS14: Belt clothing goes over outerClothing ("belt" was originally here)
     - map: [ "id" ]
     - map: [ "outerClothing" ]
+    - map: [ "belt" ] # KS14: Belt clothing goes over outerClothing
     - map: [ "back" ]
     - map: [ "neck" ]
     - map: [ "suitstorage" ]

--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -50,9 +50,17 @@
         layer:
           - SlipLayer
         mask:
-          - ItemMask
+          - LowImpassable # KS14: ItemMask -> LowImpassable
         density: 1000
         hard: false
   - type: Tag
     tags:
       - HideContextMenu
+  # KS14: lava rework: start
+  - type: KsLava
+    damage:
+      types:
+        Heat: 20
+    knockdownDuration: 1.2
+    sinkDuration: 2.5
+  # KS14: lava rework: end

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -48,9 +48,17 @@
         layer:
         - SlipLayer
         mask:
-        - ItemMask
+        - LowImpassable # KS14: ItemMask -> LowImpassable
         density: 1000
         hard: false
   - type: Tag
     tags:
     - HideContextMenu
+  # KS14: lava rework: start
+  - type: KsLava
+    damage:
+      types:
+        Heat: 20
+    knockdownDuration: 1.2
+    sinkDuration: 2.5
+  # KS14: lava rework: end

--- a/Resources/Prototypes/_KS14/Entities/Objects/Mining/orevent.yml
+++ b/Resources/Prototypes/_KS14/Entities/Objects/Mining/orevent.yml
@@ -248,7 +248,7 @@
 
 - type: oreWellSetting
   id: Basic
-  totalResourceRateRange: 0.3,0.8
+  totalResourceRateRange: 0.25,0.45
   resourceCountRange: 2,3
   possibleResourceTypes:
   - SteelOre

--- a/Resources/Prototypes/_KS14/Entities/Structures/Machines/mining.yml
+++ b/Resources/Prototypes/_KS14/Entities/Structures/Machines/mining.yml
@@ -134,7 +134,6 @@
         - MachineMask
         layer:
         - MachineLayer
-        - Impassable
 
   - type: Conveyor
     angle: -90

--- a/Resources/Prototypes/_KS14/GameRules/nightshift.yml
+++ b/Resources/Prototypes/_KS14/GameRules/nightshift.yml
@@ -31,3 +31,5 @@
   - type: StationEvent
     duration: 1890
     maxDuration: 1890
+  - type: NightshiftRule
+    color: '#707391'

--- a/Resources/Prototypes/_KS14/NPCs/Operative/operative_advance.yml
+++ b/Resources/Prototypes/_KS14/NPCs/Operative/operative_advance.yml
@@ -33,6 +33,9 @@
     components:
     - type: NpcCampingSpot
   considerations:
+  - !type:RandomValueCon # A tad bit of randomness
+    curve: !type:BoolCurve
+    probability: 0.4
   - !type:TargetDistanceCon
     curve: !type:PresetCurve
       preset: KsTargetDistanceLessClose

--- a/Resources/Prototypes/_KS14/NPCs/Operative/operative_healing.yml
+++ b/Resources/Prototypes/_KS14/NPCs/Operative/operative_healing.yml
@@ -74,6 +74,11 @@
   - tasks:
     - !type:HTNCompoundTask
       task: KsOperativeConsiderHealingCompound
+
+  - preconditions:
+    - !type:KeyExistsPrecondition
+      key: RetreatTargetCoordinates
+    tasks:
     - !type:HTNPrimitiveTask # Wait until we finish moving to our retreat position
       operator: !type:WaitUntilNullOperator
         key: RetreatTargetCoordinates
@@ -137,10 +142,14 @@
     key: OwnerCoordinates
     curve: !type:PresetCurve
       preset: TargetDistance
+  - !type:CoordinatesInFOVCon
+    curve: !type:InverseBoolCurve
+    toKey: LastTargetCoordinates
+    angle: 65
   - !type:CoordinatesInLOSCon # Dont go to markers that have LOS of where the target was
     curve: !type:InverseBoolCurve
     toKey: LastTargetCoordinates
-    radius: 5
+    radius: 7.5
 
 - type: utilityQuery
   id: KsInventoryMeds

--- a/Resources/Prototypes/_KS14/NPCs/Operative/operative_healing.yml
+++ b/Resources/Prototypes/_KS14/NPCs/Operative/operative_healing.yml
@@ -130,7 +130,6 @@
         pathfindKey: RetreatTargetPathfind
         rangeKey: CampingRange
 
-
 - type: utilityQuery
   id: KsOperativeRetreatableCampingMarkers
   query:
@@ -142,7 +141,7 @@
     key: OwnerCoordinates
     curve: !type:PresetCurve
       preset: TargetDistance
-  - !type:CoordinatesInFOVCon
+  - !type:CoordinatesInFOVCon # Don't go in the direction of the target ffs
     curve: !type:InverseBoolCurve
     toKey: LastTargetCoordinates
     angle: 65

--- a/Resources/Prototypes/_KS14/Procedural/BiomeMarkers/orevent.yml
+++ b/Resources/Prototypes/_KS14/Procedural/BiomeMarkers/orevent.yml
@@ -7,9 +7,17 @@
   maxCount: 15
 
 - type: biomeMarkerLayer
-  id: OreVentsIce
-  prototype: KsOreVentIce
+  id: OreVentsIceBasic
+  prototype: KsOreVentIceBasic
   minGroupSize: 1
   maxGroupSize: 1
   radius: 50
-  maxCount: 15
+  maxCount: 10
+
+- type: biomeMarkerLayer
+  id: OreVentsIceRare
+  prototype: KsOreVentIceRare
+  minGroupSize: 1
+  maxGroupSize: 1
+  radius: 50
+  maxCount: 5

--- a/Resources/Prototypes/_KS14/Procedural/BiomeMarkers/orevent.yml
+++ b/Resources/Prototypes/_KS14/Procedural/BiomeMarkers/orevent.yml
@@ -12,7 +12,6 @@
   minGroupSize: 1
   maxGroupSize: 1
   radius: 50
-  maxCount: 10
 
 - type: biomeMarkerLayer
   id: OreVentsIceRare
@@ -20,4 +19,4 @@
   minGroupSize: 1
   maxGroupSize: 1
   radius: 50
-  maxCount: 5
+  maxCount: 8

--- a/Resources/Textures/Shaders/hcut.swsl
+++ b/Resources/Textures/Shaders/hcut.swsl
@@ -1,7 +1,8 @@
 light_mode unshaded;
 
-const highp float c = 0.3;
-const highp float alphaModifier = 0.2;
+// KS14: Made `c` and `alphaModifier` into `uniform` from `const`
+uniform highp float c = 0.3;
+uniform highp float alphaModifier = 0.2;
 const bool below = true;
 
 void fragment()


### PR DESCRIPTION
when combatant NPCs are trying to flee from a target while healing, they will now try their hardest to NOT go in the direction of the target

also reworked lava to stun you+damage when youre on the edge, and atomise you if youre surrounded by lava

**Changelog**
:cl:
- fix: Fixed ore vents destroying saltern's planetgen.
- fix: Fixed bloodsprays appearing for all damage types instead of just bloodloss.
- tweak: Made saltern's planetgen more aggressive.
- tweak: Lava/liquid plasma is much more dangerous now.