### PR TITLE
Fix duplicate entry for en_GB-alba-medium in voices.yml

### DIFF
--- a/Resources/Prototypes/_KS14/TTS/voices.yml
+++ b/Resources/Prototypes/_KS14/TTS/voices.yml
@@ -7,12 +7,12 @@
   voice: en_GB-alan-medium
 
 - type: ttsVoice
-  id: en_GB-alba-medium
-  voice: en_GB-alba-medium
-
-- type: ttsVoice
   id: en_GB-aru-medium
   voice: en_GB-aru-medium
+
+- type: ttsVoice
+  id: en_GB-alba-medium
+  voice: en_GB-alba-medium
 
 - type: ttsVoice
   id: en_GB-cori-medium


### PR DESCRIPTION
Removed duplicate entry for 'en_GB-alba-medium' and adjusted formatting.

## What was changed
<!-- If changelog sufficiently describes your changes, you may omit this section -->

## Why

## Media

## Requirements
- [ ] Tested, works.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] Design doc

## Breaking changes
<!-- List any changes that might break future work -->

**Changelog**
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
