### PR TITLE
green glow stick uranium

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -117,6 +117,26 @@
     glowColorLit: "#00FF00"
   - type: PointLight
     color: "#00FF00"
+    # KS14: maints chem stuff
+  - type: Extractable
+    grindableSolutionName: greenGlowstick
+  - type: SolutionContainerManager
+    solutions:
+      greenGlowstick:
+        maxVol: 10
+        reagents:
+        # hydrogen peroxide o algo
+        - ReagentId: Water
+          Quantity: 2
+        - ReagentId: Hydrogen
+          Quantity: 2
+        # just cause... ok?
+        - ReagentId: Chlorine
+          Quantity: 1
+        # cuz its like green or something
+        - ReagentId: Uranium
+          Quantity: 5
+    # KS14: End
 
 # ----------------------------------------------------------------------------
 # THE FOLLOWING ARE ALL DUMMY ENTITIES USED TO TEST THE LIGHT BEHAVIOUR SYSTEM


### PR DESCRIPTION
## What was changed
<!-- If changelog sufficiently describes your changes, you may omit this section -->
green glow stick is now cool and can be grinded into uranium cuz maints tiders dont have that stuff and like i want to make EMP bombs as maints tider and this is cool and green glowsticks are kindof rare. its still 50:50 unpure solution.
## Why
for tider maints chem stuff
## Media

## Requirements
- [x] Tested, works.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] Design doc

## Breaking changes
<!-- List any changes that might break future work -->

**Changelog**
:cl:
- add: Greensticks now be grinded for uranium and hydrogen peroxide O ALGYX
