### PR TITLE
Anomaly gas interplay

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -297,7 +297,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         // Anomaly health
         if (component.IgnoreSecret)
         {
-            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-health", ("health", (anomalyComp.Health * 100).ToString("F1"))));
+            msg.AddMarkupOrThrow(Loc.GetString("ks-anomaly-scanner-health", ("health", (anomalyComp.Health * 100).ToString("F1"))));
             msg.PushNewline();
         }
         // KS14 - End

--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -1,7 +1,6 @@
 using Content.Server.Anomaly.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared._KS14.Anomaly.Components; // KS14
-using Content.Shared._KS14.Anomaly.Prototypes; // KS14
 using Content.Server.Audio;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Materials;
@@ -362,7 +361,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         msg.PushNewline();
 
         // KS14 - Start
-        msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-title"));
+        msg.AddMarkupOrThrow(Loc.GetString("ks-anomaly-scanner-atmosphere-title"));
         msg.PushNewline();
 
         if (TryComp<AnomalyGasConsumerComponent>(anomaly, out var consumer) && consumer.PrimaryGas != null)
@@ -378,7 +377,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
             }
             var pGasName = Loc.TryGetString($"gas-{pGasId}", out var pName) ? pName : (Loc.TryGetString($"gases-{pGasId}", out pName) ? pName : pGasNameStr);
 
-            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-primary",
+            msg.AddMarkupOrThrow(Loc.GetString("ks-anomaly-scanner-atmosphere-primary",
                 ("gas", pGasName),
                 ("percent", (consumer.PrimaryScalingFactor * 100).ToString("F0"))));
             msg.PushNewline();
@@ -396,7 +395,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
                 }
                 var sGasName = Loc.TryGetString($"gas-{sGasId}", out var sName) ? sName : (Loc.TryGetString($"gases-{sGasId}", out sName) ? sName : sGasNameStr);
 
-                msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-secondary",
+                msg.AddMarkupOrThrow(Loc.GetString("ks-anomaly-scanner-atmosphere-secondary",
                     ("gas", sGasName),
                     ("percent", (consumer.SecondaryScalingFactor * 100).ToString("F0"))));
                 msg.PushNewline();
@@ -415,7 +414,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         }
         else
         {
-            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-none"));
+            msg.AddMarkupOrThrow(Loc.GetString("ks-anomaly-scanner-atmosphere-none"));
             msg.PushNewline();
             msg.PushNewline();
         }

--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.Anomaly.Components;
 using Content.Server.Atmos.EntitySystems;
+using Content.Shared._KS14.Anomaly.Components; // KS14
+using Content.Shared._KS14.Anomaly.Prototypes; // KS14
 using Content.Server.Audio;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Materials;
@@ -57,6 +59,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         InitializeGenerator();
         InitializeVessel();
         InitializeCommands();
+        InitializeGases(); // KS14
     }
 
     private void OnMapInit(Entity<AnomalyComponent> anomaly, ref MapInitEvent args)
@@ -161,6 +164,13 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
             multiplier *= behavior.EarnPointModifier;
         }
 
+        // KS14 - Start
+        if (TryComp<AnomalyGasConsumerComponent>(anomaly, out var consumer))
+        {
+            multiplier *= consumer.PointMultiplier;
+        }
+        // KS14 - End
+
         var severityValue = 1 / (1 + MathF.Pow(MathF.E, -7 * (component.Severity - 0.5f)));
 
         return (int)((component.MaxPointsPerSecond - component.MinPointsPerSecond) * severityValue * multiplier) + component.MinPointsPerSecond;
@@ -182,13 +192,13 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
             _ => throw new ArgumentOutOfRangeException()
         };
     }
-
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
         UpdateGenerator();
         UpdateVessels();
+        UpdateGasConsumption(frameTime); // KS14
     }
 
     #region Behavior
@@ -283,6 +293,16 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
             msg.AddMarkupOrThrow(text);
         }
         msg.PushNewline();
+
+        // KS14 - Start
+        // Anomaly health
+        if (component.IgnoreSecret)
+        {
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-health", ("health", (anomalyComp.Health * 100).ToString("F1"))));
+            msg.PushNewline();
+        }
+        // KS14 - End
+
         msg.PushNewline();
 
         //Particles title
@@ -340,6 +360,41 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         //Behavior
         msg.PushNewline();
         msg.PushNewline();
+
+        // KS14 - Start
+        msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-title"));
+        msg.PushNewline();
+
+        if (TryComp<AnomalyGasConsumerComponent>(anomaly, out var consumer) && consumer.ActiveGas != null)
+        {
+            // Try to find localized gas name
+            // Convert PascalCase to kebab-case for localization keys (e.g. CarbonDioxide -> carbon-dioxide)
+            var gasNameStr = consumer.ActiveGas.Value.ToString();
+            var gasId = "";
+            for (var i = 0; i < gasNameStr.Length; i++)
+            {
+                var c = gasNameStr[i];
+                if (i > 0 && char.IsUpper(c))
+                    gasId += "-";
+                gasId += char.ToLower(c);
+            }
+
+            var gasName = Loc.TryGetString($"gas-{gasId}", out var name) ? name : (Loc.TryGetString($"gases-{gasId}", out name) ? name : gasNameStr);
+
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-active",
+                ("gas", gasName),
+                ("percent", (consumer.ScalingFactor * 100).ToString("F0"))));
+            msg.PushNewline();
+            msg.PushNewline();
+        }
+        else
+        {
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-none"));
+            msg.PushNewline();
+            msg.PushNewline();
+        }
+        // KS14 - End
+
         var behaviorTitle = Loc.GetString("anomaly-behavior-title");
         if (secret != null && secret.Secret.Contains(AnomalySecretData.Behavior) && component.IgnoreSecret)
             behaviorTitle += " " + Loc.GetString("anomaly-secret-admin");

--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -365,26 +365,52 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-title"));
         msg.PushNewline();
 
-        if (TryComp<AnomalyGasConsumerComponent>(anomaly, out var consumer) && consumer.ActiveGas != null)
+        if (TryComp<AnomalyGasConsumerComponent>(anomaly, out var consumer) && consumer.PrimaryGas != null)
         {
-            // Try to find localized gas name
-            // Convert PascalCase to kebab-case for localization keys (e.g. CarbonDioxide -> carbon-dioxide)
-            var gasNameStr = consumer.ActiveGas.Value.ToString();
-            var gasId = "";
-            for (var i = 0; i < gasNameStr.Length; i++)
+            // Primary Gas
+            var pGasNameStr = consumer.PrimaryGas.Value.ToString();
+            var pGasId = "";
+            for (var i = 0; i < pGasNameStr.Length; i++)
             {
-                var c = gasNameStr[i];
-                if (i > 0 && char.IsUpper(c))
-                    gasId += "-";
-                gasId += char.ToLower(c);
+                var c = pGasNameStr[i];
+                if (i > 0 && char.IsUpper(c)) pGasId += "-";
+                pGasId += char.ToLower(c);
+            }
+            var pGasName = Loc.TryGetString($"gas-{pGasId}", out var pName) ? pName : (Loc.TryGetString($"gases-{pGasId}", out pName) ? pName : pGasNameStr);
+
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-primary",
+                ("gas", pGasName),
+                ("percent", (consumer.PrimaryScalingFactor * 100).ToString("F0"))));
+            msg.PushNewline();
+
+            // Secondary Gas
+            if (consumer.SecondaryGas != null && consumer.SecondaryScalingFactor > 0)
+            {
+                var sGasNameStr = consumer.SecondaryGas.Value.ToString();
+                var sGasId = "";
+                for (var i = 0; i < sGasNameStr.Length; i++)
+                {
+                    var c = sGasNameStr[i];
+                    if (i > 0 && char.IsUpper(c)) sGasId += "-";
+                    sGasId += char.ToLower(c);
+                }
+                var sGasName = Loc.TryGetString($"gas-{sGasId}", out var sName) ? sName : (Loc.TryGetString($"gases-{sGasId}", out sName) ? sName : sGasNameStr);
+
+                msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-secondary",
+                    ("gas", sGasName),
+                    ("percent", (consumer.SecondaryScalingFactor * 100).ToString("F0"))));
+                msg.PushNewline();
             }
 
-            var gasName = Loc.TryGetString($"gas-{gasId}", out var name) ? name : (Loc.TryGetString($"gases-{gasId}", out name) ? name : gasNameStr);
+            if (component.IgnoreSecret)
+            {
+                // Calculate partial pressure for debug (approximate)
+                msg.PushColor(Color.DarkGray);
+                msg.AddText($"[Debug] Moles: {consumer.PointMultiplier:F2}x Pts, {consumer.PulseFrequencyMultiplier:F2}x Freq");
+                msg.Pop();
+                msg.PushNewline();
+            }
 
-            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-atmosphere-active",
-                ("gas", gasName),
-                ("percent", (consumer.ScalingFactor * 100).ToString("F0"))));
-            msg.PushNewline();
             msg.PushNewline();
         }
         else

--- a/Content.Server/_KS14/Anomaly/AnomalySystem.Gases.cs
+++ b/Content.Server/_KS14/Anomaly/AnomalySystem.Gases.cs
@@ -15,7 +15,8 @@ public sealed partial class AnomalySystem
     private sealed class GasConsumerProcessingState
     {
         public float Accumulator;
-        public float LastSentScalingFactor = -1f;
+        public float LastSentPrimaryScaling = -1f;
+        public float LastSentSecondaryScaling = -1f;
     }
 
     private readonly Dictionary<EntityUid, GasConsumerProcessingState> _processingCache = new();
@@ -83,75 +84,114 @@ public sealed partial class AnomalySystem
                 continue;
             }
 
-            // Find dominant gas
-            Gas? dominantGas = null;
-            float maxMoles = 0;
+            // Find dominant top 2 gases
+            Gas? primaryGas = null;
+            float primaryMoles = 0;
+            Gas? secondaryGas = null;
+            float secondaryMoles = 0;
 
             foreach (var gas in _gasValues)
             {
+                if (gas == Gas.Nitrogen)
+                    continue;
+
                 var moles = mixture.GetMoles(gas);
-                if (moles > maxMoles)
+                if (moles <= 0) continue;
+
+                if (moles > primaryMoles)
                 {
-                    maxMoles = moles;
-                    dominantGas = gas;
+                    secondaryGas = primaryGas;
+                    secondaryMoles = primaryMoles;
+                    primaryGas = gas;
+                    primaryMoles = moles;
+                }
+                else if (moles > secondaryMoles)
+                {
+                    secondaryGas = gas;
+                    secondaryMoles = moles;
                 }
             }
 
-            if (dominantGas == null || dominantGas == Gas.Nitrogen)
+            // Calculate primary partial pressure directly from the mixture's total pressure
+            float primaryPressure = primaryMoles > 0 ? mixture.Pressure * (primaryMoles / mixture.TotalMoles) : 0f;
+            float secondaryPressure = secondaryMoles > 0 ? mixture.Pressure * (secondaryMoles / mixture.TotalMoles) : 0f;
+
+            if (primaryGas == null || primaryPressure < consumer.MinPressureThreshold || !_gasEffects.ContainsKey(primaryGas.Value))
             {
                 ResetGasState(uid, consumer, state);
                 continue;
             }
 
-            // Calculate partial pressure directly from the mixture's total pressure
-            var partialPressure = mixture.Pressure * (maxMoles / mixture.TotalMoles);
-
-            if (partialPressure < consumer.MinPressureThreshold)
+            // Process Primary
+            var primaryScaling = Math.Clamp((primaryPressure - consumer.MinPressureThreshold) / (consumer.MaxPressureCap - consumer.MinPressureThreshold), 0f, 1f);
+            var primaryEffect = _gasEffects[primaryGas.Value];
+            
+            // Process Secondary
+            float secondaryScaling = 0f;
+            AnomalyGasEffectPrototype? secondaryEffect = null;
+            if (secondaryGas != null && secondaryPressure >= consumer.MinPressureThreshold && _gasEffects.TryGetValue(secondaryGas.Value, out secondaryEffect))
             {
-                ResetGasState(uid, consumer, state);
-                continue;
+                secondaryScaling = Math.Clamp((secondaryPressure - consumer.MinPressureThreshold) / (consumer.MaxPressureCap - consumer.MinPressureThreshold), 0f, 1f);
             }
 
-            if (!_gasEffects.TryGetValue(dominantGas.Value, out var effect))
-            {
-                ResetGasState(uid, consumer, state);
-                // Log warning for missing non-inert prototypes
-                Log.Warning($"Anomaly {ToPrettyString(uid)} is in {dominantGas.Value} but no AnomalyGasEffectPrototype is defined for it.");
-                continue;
-            }
+            // Calculate total deltas and multipliers
+            float stabDelta = primaryEffect.StabilityModifier * primaryScaling;
+            float sevDelta = primaryEffect.SeverityModifier * primaryScaling;
+            float healthDelta = primaryEffect.HealthModifier * primaryScaling;
+            
+            float ptMult = (primaryEffect.PointMultiplier - 1f) * primaryScaling;
+            float freqMult = (primaryEffect.PulseFrequencyMultiplier - 1f) * primaryScaling;
+            float decBuffer = (primaryEffect.DecayBuffer - 1f) * primaryScaling;
+            float powMult = (primaryEffect.PulsePowerMultiplier - 1f) * primaryScaling;
 
-            // Scaling calculation
-            var scaling = Math.Clamp((partialPressure - consumer.MinPressureThreshold) / (consumer.MaxPressureCap - consumer.MinPressureThreshold), 0f, 1f);
+            if (secondaryEffect != null && secondaryScaling > 0)
+            {
+                float secFactor = secondaryScaling * consumer.SecondaryGasPenalty;
+                stabDelta += secondaryEffect.StabilityModifier * secFactor;
+                sevDelta += secondaryEffect.SeverityModifier * secFactor;
+                healthDelta += secondaryEffect.HealthModifier * secFactor;
+
+                ptMult += (secondaryEffect.PointMultiplier - 1f) * secFactor;
+                freqMult += (secondaryEffect.PulseFrequencyMultiplier - 1f) * secFactor;
+                decBuffer += (secondaryEffect.DecayBuffer - 1f) * secFactor;
+                powMult += (secondaryEffect.PulsePowerMultiplier - 1f) * secFactor;
+            }
 
             // Apply continuous modifiers
-            if (effect.StabilityModifier != 0)
-                ChangeAnomalyStability(uid, effect.StabilityModifier * scaling * elapsed, anomaly);
+            if (stabDelta != 0) ChangeAnomalyStability(uid, stabDelta * elapsed, anomaly);
+            if (sevDelta != 0) ChangeAnomalySeverity(uid, sevDelta * elapsed, anomaly);
+            if (healthDelta != 0) ChangeAnomalyHealth(uid, healthDelta * elapsed, anomaly);
 
-            if (effect.SeverityModifier != 0)
-                ChangeAnomalySeverity(uid, effect.SeverityModifier * scaling * elapsed, anomaly);
-
-            if (effect.HealthModifier != 0)
-                ChangeAnomalyHealth(uid, effect.HealthModifier * scaling * elapsed, anomaly);
-
-            // Update multipliers for shared logic
-            consumer.PointMultiplier = 1f + (effect.PointMultiplier - 1f) * scaling;
-            consumer.PulseFrequencyMultiplier = 1f + (effect.PulseFrequencyMultiplier - 1f) * scaling;
-            consumer.DecayBuffer = 1f + (effect.DecayBuffer - 1f) * scaling;
-            consumer.PulsePowerMultiplier = 1f + (effect.PulsePowerMultiplier - 1f) * scaling;
+            // Update multipliers
+            consumer.PointMultiplier = 1f + ptMult;
+            consumer.PulseFrequencyMultiplier = 1f + freqMult;
+            consumer.DecayBuffer = 1f + decBuffer;
+            consumer.PulsePowerMultiplier = 1f + powMult;
 
             // Consume gas
-            var consumed = consumer.ConsumptionRate * scaling * elapsed;
-            mixture.AdjustMoles(dominantGas.Value, -consumed);
+            var primaryConsumed = consumer.ConsumptionRate * primaryScaling * elapsed;
+            mixture.AdjustMoles(primaryGas.Value, -primaryConsumed);
+
+            if (secondaryEffect != null && secondaryScaling > 0)
+            {
+                var secondaryConsumed = consumer.ConsumptionRate * secondaryScaling * elapsed;
+                mixture.AdjustMoles(secondaryGas!.Value, -secondaryConsumed);
+            }
 
             // Networking threshold check
-            var gasChanged = consumer.ActiveGas != dominantGas;
-            var scalingThresholdMet = Math.Abs(scaling - state.LastSentScalingFactor) >= 0.1f;
+            var gasChanged = consumer.PrimaryGas != primaryGas || consumer.SecondaryGas != secondaryGas;
+            var primaryMet = Math.Abs(primaryScaling - state.LastSentPrimaryScaling) >= 0.1f;
+            var secondaryMet = Math.Abs(secondaryScaling - state.LastSentSecondaryScaling) >= 0.1f;
 
-            if (gasChanged || scalingThresholdMet)
+            if (gasChanged || primaryMet || secondaryMet)
             {
-                consumer.ActiveGas = dominantGas;
-                consumer.ScalingFactor = scaling;
-                state.LastSentScalingFactor = scaling;
+                consumer.PrimaryGas = primaryGas;
+                consumer.SecondaryGas = secondaryGas;
+                consumer.PrimaryScalingFactor = primaryScaling;
+                consumer.SecondaryScalingFactor = secondaryScaling;
+                
+                state.LastSentPrimaryScaling = primaryScaling;
+                state.LastSentSecondaryScaling = secondaryScaling;
                 Dirty(uid, consumer);
             }
         }
@@ -159,12 +199,16 @@ public sealed partial class AnomalySystem
 
     private void ResetGasState(EntityUid uid, AnomalyGasConsumerComponent consumer, GasConsumerProcessingState state)
     {
-        if (consumer.ActiveGas == null && state.LastSentScalingFactor == -1f)
+        if (consumer.PrimaryGas == null && state.LastSentPrimaryScaling == -1f)
             return;
 
-        consumer.ActiveGas = null;
-        consumer.ScalingFactor = 0f;
-        state.LastSentScalingFactor = -1f;
+        consumer.PrimaryGas = null;
+        consumer.SecondaryGas = null;
+        consumer.PrimaryScalingFactor = 0f;
+        consumer.SecondaryScalingFactor = 0f;
+        
+        state.LastSentPrimaryScaling = -1f;
+        state.LastSentSecondaryScaling = -1f;
 
         consumer.PointMultiplier = 1f;
         consumer.PulseFrequencyMultiplier = 1f;

--- a/Content.Server/_KS14/Anomaly/AnomalySystem.Gases.cs
+++ b/Content.Server/_KS14/Anomaly/AnomalySystem.Gases.cs
@@ -1,0 +1,176 @@
+using Content.Shared.Anomaly.Components; // KS14
+using Content.Shared._KS14.Anomaly.Components;
+using Content.Shared._KS14.Anomaly.Prototypes;
+using Content.Shared.Atmos;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Anomaly;
+
+public sealed partial class AnomalySystem
+{
+    /// <summary>
+    /// Transient cache for processing accumulators and networking thresholds.
+    /// </summary>
+    private sealed class GasConsumerProcessingState
+    {
+        public float Accumulator;
+        public float LastSentScalingFactor = -1f;
+    }
+
+    private readonly Dictionary<EntityUid, GasConsumerProcessingState> _processingCache = new();
+    private readonly Dictionary<Gas, AnomalyGasEffectPrototype> _gasEffects = new();
+    private Gas[] _gasValues = Array.Empty<Gas>();
+
+    private void InitializeGases()
+    {
+        SubscribeLocalEvent<AnomalyGasConsumerComponent, ComponentShutdown>(OnGasConsumerShutdown);
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
+        _gasValues = Enum.GetValues<Gas>();
+        CacheGasEffects();
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
+    {
+        if (args.WasModified<AnomalyGasEffectPrototype>())
+            CacheGasEffects();
+    }
+
+    private void CacheGasEffects()
+    {
+        _gasEffects.Clear();
+        foreach (var proto in _prototype.EnumeratePrototypes<AnomalyGasEffectPrototype>())
+        {
+            _gasEffects[proto.Gas] = proto;
+        }
+    }
+
+    private void OnGasConsumerShutdown(EntityUid uid, AnomalyGasConsumerComponent component, ComponentShutdown args)
+    {
+        _processingCache.Remove(uid);
+    }
+
+    private void UpdateGasConsumption(float frameTime)
+    {
+        var query = EntityQueryEnumerator<AnomalyGasConsumerComponent, AnomalyComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var consumer, out var anomaly, out var xform))
+        {
+            if (!_processingCache.TryGetValue(uid, out var state))
+            {
+                state = new GasConsumerProcessingState();
+                _processingCache[uid] = state;
+            }
+
+            state.Accumulator += frameTime;
+            var interval = Math.Clamp(consumer.UpdateInterval, 0.5f, 2.0f);
+
+            if (state.Accumulator < interval)
+                continue;
+
+            var elapsed = state.Accumulator;
+            state.Accumulator = 0;
+
+            if (xform.GridUid == null)
+            {
+                ResetGasState(uid, consumer, state);
+                continue;
+            }
+
+            var mixture = _atmosphere.GetContainingMixture(uid, false, true);
+            if (mixture == null || mixture.TotalMoles <= 0)
+            {
+                ResetGasState(uid, consumer, state);
+                continue;
+            }
+
+            // Find dominant gas
+            Gas? dominantGas = null;
+            float maxMoles = 0;
+
+            foreach (var gas in _gasValues)
+            {
+                var moles = mixture.GetMoles(gas);
+                if (moles > maxMoles)
+                {
+                    maxMoles = moles;
+                    dominantGas = gas;
+                }
+            }
+
+            if (dominantGas == null || dominantGas == Gas.Nitrogen)
+            {
+                ResetGasState(uid, consumer, state);
+                continue;
+            }
+
+            // Calculate partial pressure directly from the mixture's total pressure
+            var partialPressure = mixture.Pressure * (maxMoles / mixture.TotalMoles);
+
+            if (partialPressure < consumer.MinPressureThreshold)
+            {
+                ResetGasState(uid, consumer, state);
+                continue;
+            }
+
+            if (!_gasEffects.TryGetValue(dominantGas.Value, out var effect))
+            {
+                ResetGasState(uid, consumer, state);
+                // Log warning for missing non-inert prototypes
+                Log.Warning($"Anomaly {ToPrettyString(uid)} is in {dominantGas.Value} but no AnomalyGasEffectPrototype is defined for it.");
+                continue;
+            }
+
+            // Scaling calculation
+            var scaling = Math.Clamp((partialPressure - consumer.MinPressureThreshold) / (consumer.MaxPressureCap - consumer.MinPressureThreshold), 0f, 1f);
+
+            // Apply continuous modifiers
+            if (effect.StabilityModifier != 0)
+                ChangeAnomalyStability(uid, effect.StabilityModifier * scaling * elapsed, anomaly);
+
+            if (effect.SeverityModifier != 0)
+                ChangeAnomalySeverity(uid, effect.SeverityModifier * scaling * elapsed, anomaly);
+
+            if (effect.HealthModifier != 0)
+                ChangeAnomalyHealth(uid, effect.HealthModifier * scaling * elapsed, anomaly);
+
+            // Update multipliers for shared logic
+            consumer.PointMultiplier = 1f + (effect.PointMultiplier - 1f) * scaling;
+            consumer.PulseFrequencyMultiplier = 1f + (effect.PulseFrequencyMultiplier - 1f) * scaling;
+            consumer.DecayBuffer = 1f + (effect.DecayBuffer - 1f) * scaling;
+            consumer.PulsePowerMultiplier = 1f + (effect.PulsePowerMultiplier - 1f) * scaling;
+
+            // Consume gas
+            var consumed = consumer.ConsumptionRate * scaling * elapsed;
+            mixture.AdjustMoles(dominantGas.Value, -consumed);
+
+            // Networking threshold check
+            var gasChanged = consumer.ActiveGas != dominantGas;
+            var scalingThresholdMet = Math.Abs(scaling - state.LastSentScalingFactor) >= 0.1f;
+
+            if (gasChanged || scalingThresholdMet)
+            {
+                consumer.ActiveGas = dominantGas;
+                consumer.ScalingFactor = scaling;
+                state.LastSentScalingFactor = scaling;
+                Dirty(uid, consumer);
+            }
+        }
+    }
+
+    private void ResetGasState(EntityUid uid, AnomalyGasConsumerComponent consumer, GasConsumerProcessingState state)
+    {
+        if (consumer.ActiveGas == null && state.LastSentScalingFactor == -1f)
+            return;
+
+        consumer.ActiveGas = null;
+        consumer.ScalingFactor = 0f;
+        state.LastSentScalingFactor = -1f;
+
+        consumer.PointMultiplier = 1f;
+        consumer.PulseFrequencyMultiplier = 1f;
+        consumer.DecayBuffer = 1f;
+        consumer.PulsePowerMultiplier = 1f;
+
+        Dirty(uid, consumer);
+    }
+}

--- a/Content.Server/_KS14/Anomaly/AnomalySystem.Gases.cs
+++ b/Content.Server/_KS14/Anomaly/AnomalySystem.Gases.cs
@@ -125,7 +125,7 @@ public sealed partial class AnomalySystem
             // Process Primary
             var primaryScaling = Math.Clamp((primaryPressure - consumer.MinPressureThreshold) / (consumer.MaxPressureCap - consumer.MinPressureThreshold), 0f, 1f);
             var primaryEffect = _gasEffects[primaryGas.Value];
-            
+
             // Process Secondary
             float secondaryScaling = 0f;
             AnomalyGasEffectPrototype? secondaryEffect = null;
@@ -138,7 +138,7 @@ public sealed partial class AnomalySystem
             float stabDelta = primaryEffect.StabilityModifier * primaryScaling;
             float sevDelta = primaryEffect.SeverityModifier * primaryScaling;
             float healthDelta = primaryEffect.HealthModifier * primaryScaling;
-            
+
             float ptMult = (primaryEffect.PointMultiplier - 1f) * primaryScaling;
             float freqMult = (primaryEffect.PulseFrequencyMultiplier - 1f) * primaryScaling;
             float decBuffer = (primaryEffect.DecayBuffer - 1f) * primaryScaling;
@@ -189,7 +189,7 @@ public sealed partial class AnomalySystem
                 consumer.SecondaryGas = secondaryGas;
                 consumer.PrimaryScalingFactor = primaryScaling;
                 consumer.SecondaryScalingFactor = secondaryScaling;
-                
+
                 state.LastSentPrimaryScaling = primaryScaling;
                 state.LastSentSecondaryScaling = secondaryScaling;
                 Dirty(uid, consumer);
@@ -206,7 +206,7 @@ public sealed partial class AnomalySystem
         consumer.SecondaryGas = null;
         consumer.PrimaryScalingFactor = 0f;
         consumer.SecondaryScalingFactor = 0f;
-        
+
         state.LastSentPrimaryScaling = -1f;
         state.LastSentSecondaryScaling = -1f;
 

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Anomaly.Components;
+using Content.Shared._KS14.Anomaly.Components; // KS14
 using Content.Shared.Anomaly.Prototypes;
 using Content.Shared.Database;
 using Content.Shared.Physics;
@@ -341,7 +342,13 @@ public abstract class SharedAnomalySystem : EntitySystem
             // update it every second to start killing it slowly.
             if (anomaly.Stability < anomaly.DecayThreshold)
             {
-                ChangeAnomalyHealth(ent, anomaly.HealthChangePerSecond * frameTime, anomaly);
+                // KS14 - Start
+                var healthChange = anomaly.HealthChangePerSecond;
+                if (TryComp<AnomalyGasConsumerComponent>(ent, out var consumer))
+                    healthChange *= consumer.DecayBuffer;
+
+                ChangeAnomalyHealth(ent, healthChange * frameTime, anomaly);
+                // KS14 - End
             }
 
             var secondsUntilNextPulse = (anomaly.NextPulseTime - Timing.CurTime).TotalSeconds;

--- a/Content.Shared/_KS14/Anomaly/Components/AnomalyGasConsumerComponent.cs
+++ b/Content.Shared/_KS14/Anomaly/Components/AnomalyGasConsumerComponent.cs
@@ -29,6 +29,12 @@ public sealed partial class AnomalyGasConsumerComponent : Component
     public float ConsumptionRate = 1.0f;
 
     /// <summary>
+    /// Penalty multiplier applied to the secondary gas effect.
+    /// </summary>
+    [DataField("secondaryGasPenalty")]
+    public float SecondaryGasPenalty = 0.5f;
+
+    /// <summary>
     /// How often the anomaly checks the atmosphere (in seconds).
     /// Capped between 0.5 and 2.0 in logic.
     /// </summary>
@@ -38,19 +44,30 @@ public sealed partial class AnomalyGasConsumerComponent : Component
 
     #region Gameplay State
     /// <summary>
-    /// The gas currently affecting the anomaly.
+    /// The primary gas currently affecting the anomaly.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
-    public Gas? ActiveGas;
+    public Gas? PrimaryGas;
 
     /// <summary>
-    /// The strength of the gas effect (0.0 to 1.0), based on pressure.
+    /// The secondary gas currently affecting the anomaly.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
-    public float ScalingFactor = 0f;
+    public Gas? SecondaryGas;
 
-    [AutoNetworkedField]
-    public float PointMultiplier = 1f;
+    /// <summary>
+    /// The strength of the primary gas effect (0.0 to 1.0), based on pressure.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public float PrimaryScalingFactor = 0f;
+
+    /// <summary>
+    /// The strength of the secondary gas effect (0.0 to 1.0), based on pressure.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public float SecondaryScalingFactor = 0f;
+
+    [AutoNetworkedField]    public float PointMultiplier = 1f;
 
     [AutoNetworkedField]
     public float PulseFrequencyMultiplier = 1f;

--- a/Content.Shared/_KS14/Anomaly/Components/AnomalyGasConsumerComponent.cs
+++ b/Content.Shared/_KS14/Anomaly/Components/AnomalyGasConsumerComponent.cs
@@ -1,0 +1,64 @@
+using Content.Shared.Atmos;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._KS14.Anomaly.Components;
+
+/// <summary>
+/// This component allows an anomaly to interact with the gases in its environment.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AnomalyGasConsumerComponent : Component
+{
+    #region Configuration
+    /// <summary>
+    /// Pressure required (in kPa) to start triggering effects.
+    /// </summary>
+    [DataField("minPressureThreshold")]
+    public float MinPressureThreshold = 10f;
+
+    /// <summary>
+    /// Pressure at which the gas effect reaches 100% scaling.
+    /// </summary>
+    [DataField("maxPressureCap")]
+    public float MaxPressureCap = 500f;
+
+    /// <summary>
+    /// Baseline moles of dominant gas removed per second at 100% scaling.
+    /// </summary>
+    [DataField("consumptionRate")]
+    public float ConsumptionRate = 1.0f;
+
+    /// <summary>
+    /// How often the anomaly checks the atmosphere (in seconds).
+    /// Capped between 0.5 and 2.0 in logic.
+    /// </summary>
+    [DataField("updateInterval")]
+    public float UpdateInterval = 1.0f;
+    #endregion
+
+    #region Gameplay State
+    /// <summary>
+    /// The gas currently affecting the anomaly.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public Gas? ActiveGas;
+
+    /// <summary>
+    /// The strength of the gas effect (0.0 to 1.0), based on pressure.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public float ScalingFactor = 0f;
+
+    [AutoNetworkedField]
+    public float PointMultiplier = 1f;
+
+    [AutoNetworkedField]
+    public float PulseFrequencyMultiplier = 1f;
+
+    [AutoNetworkedField]
+    public float DecayBuffer = 1f;
+
+    [AutoNetworkedField]
+    public float PulsePowerMultiplier = 1f;
+    #endregion
+}

--- a/Content.Shared/_KS14/Anomaly/Components/AnomalyGasConsumerComponent.cs
+++ b/Content.Shared/_KS14/Anomaly/Components/AnomalyGasConsumerComponent.cs
@@ -67,7 +67,7 @@ public sealed partial class AnomalyGasConsumerComponent : Component
     [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
     public float SecondaryScalingFactor = 0f;
 
-    [AutoNetworkedField]    public float PointMultiplier = 1f;
+    [AutoNetworkedField] public float PointMultiplier = 1f;
 
     [AutoNetworkedField]
     public float PulseFrequencyMultiplier = 1f;

--- a/Content.Shared/_KS14/Anomaly/Prototypes/AnomalyGasEffectPrototype.cs
+++ b/Content.Shared/_KS14/Anomaly/Prototypes/AnomalyGasEffectPrototype.cs
@@ -1,0 +1,63 @@
+using Content.Shared.Atmos;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._KS14.Anomaly.Prototypes;
+
+/// <summary>
+/// Defines the effects a specific gas has on an anomaly when it is present in the atmosphere.
+/// </summary>
+[Prototype]
+public sealed partial class AnomalyGasEffectPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// The gas type this effect applies to.
+    /// </summary>
+    [DataField("gas", required: true)]
+    public Gas Gas;
+
+    /// <summary>
+    /// How much the stability changes per second at max scaling.
+    /// </summary>
+    [DataField("stabilityModifier")]
+    public float StabilityModifier = 0f;
+
+    /// <summary>
+    /// How much the severity changes per second at max scaling.
+    /// </summary>
+    [DataField("severityModifier")]
+    public float SeverityModifier = 0f;
+
+    /// <summary>
+    /// How much the health changes per second at max scaling (for healing or draining).
+    /// </summary>
+    [DataField("healthModifier")]
+    public float HealthModifier = 0f;
+
+    /// <summary>
+    /// The multiplier applied to research point generation.
+    /// </summary>
+    [DataField("pointMultiplier")]
+    public float PointMultiplier = 1f;
+
+    /// <summary>
+    /// The multiplier applied to the time between pulses.
+    /// </summary>
+    [DataField("pulseFrequencyMultiplier")]
+    public float PulseFrequencyMultiplier = 1f;
+
+    /// <summary>
+    /// A buffer that reduces health decay when the anomaly is in the decay range.
+    /// 1.0 means normal decay, 0.2 means 80% reduction.
+    /// </summary>
+    [DataField("decayBuffer")]
+    public float DecayBuffer = 1f;
+
+    /// <summary>
+    /// Multiplier for the power/radius of the anomaly's pulse effects.
+    /// </summary>
+    [DataField("pulsePowerMultiplier")]
+    public float PulsePowerMultiplier = 1f;
+}

--- a/Resources/Locale/en-US/_KS14/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/_KS14/anomaly/anomaly.ftl
@@ -1,0 +1,6 @@
+ks-anomaly-scanner-health = Current health: [color=gray]{$health}%[/color]
+
+ks-anomaly-scanner-atmosphere-title = Atmospheric Influence Analysis:
+ks-anomaly-scanner-atmosphere-none = Current State: [color=gray]No significant atmospheric influence[/color]
+ks-anomaly-scanner-atmosphere-primary = Primary Catalyst: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]
+ks-anomaly-scanner-atmosphere-secondary = Secondary Catalyst: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -22,8 +22,6 @@ anomaly-scanner-stability-high = Current anomaly state: [color=crimson]Growing[/
 anomaly-scanner-stability-unknown = Current anomaly state: [color=red]ERROR[/color]
 anomaly-scanner-point-output = Point output: [color=gray]{$point}[/color]
 anomaly-scanner-point-output-unknown = Point output: [color=red]ERROR[/color]
-# KS14
-anomaly-scanner-health = Current health: [color=gray]{$health}%[/color]
 anomaly-scanner-particle-readout = Particle Reaction Analysis:
 anomaly-scanner-particle-danger = - [color=crimson]Danger type:[/color] {$type}
 anomaly-scanner-particle-unstable = - [color=plum]Unstable type:[/color] {$type}
@@ -99,12 +97,6 @@ anomaly-behavior-inconstancy = [color=crimson]Impermanence has been detected. Pa
 anomaly-behavior-fast = [color=crimson]The pulsation frequency is strongly increased.[/color]
 anomaly-behavior-strenght = [color=crimson]The pulsation power is significantly increased.[/color]
 anomaly-behavior-moving = [color=crimson]Coordinate instability was detected.[/color]
-
-# KS14
-anomaly-scanner-atmosphere-title = Atmospheric Influence Analysis:
-anomaly-scanner-atmosphere-none = Current State: [color=gray]No significant atmospheric influence[/color]
-anomaly-scanner-atmosphere-primary = Primary Catalyst: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]
-anomaly-scanner-atmosphere-secondary = Secondary Catalyst: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]
 
 gorilla-shove-not-disposals = You can only shove this into a disposals unit!
 gorilla-shove-gauntlet-not-active = The gauntlet isn't active!

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -103,7 +103,8 @@ anomaly-behavior-moving = [color=crimson]Coordinate instability was detected.[/c
 # KS14
 anomaly-scanner-atmosphere-title = Atmospheric Influence Analysis:
 anomaly-scanner-atmosphere-none = Current State: [color=gray]No significant atmospheric influence[/color]
-anomaly-scanner-atmosphere-active = Current State: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]
+anomaly-scanner-atmosphere-primary = Primary Catalyst: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]
+anomaly-scanner-atmosphere-secondary = Secondary Catalyst: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]
 
 gorilla-shove-not-disposals = You can only shove this into a disposals unit!
 gorilla-shove-gauntlet-not-active = The gauntlet isn't active!

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -22,6 +22,8 @@ anomaly-scanner-stability-high = Current anomaly state: [color=crimson]Growing[/
 anomaly-scanner-stability-unknown = Current anomaly state: [color=red]ERROR[/color]
 anomaly-scanner-point-output = Point output: [color=gray]{$point}[/color]
 anomaly-scanner-point-output-unknown = Point output: [color=red]ERROR[/color]
+# KS14
+anomaly-scanner-health = Current health: [color=gray]{$health}%[/color]
 anomaly-scanner-particle-readout = Particle Reaction Analysis:
 anomaly-scanner-particle-danger = - [color=crimson]Danger type:[/color] {$type}
 anomaly-scanner-particle-unstable = - [color=plum]Unstable type:[/color] {$type}
@@ -97,6 +99,11 @@ anomaly-behavior-inconstancy = [color=crimson]Impermanence has been detected. Pa
 anomaly-behavior-fast = [color=crimson]The pulsation frequency is strongly increased.[/color]
 anomaly-behavior-strenght = [color=crimson]The pulsation power is significantly increased.[/color]
 anomaly-behavior-moving = [color=crimson]Coordinate instability was detected.[/color]
+
+# KS14
+anomaly-scanner-atmosphere-title = Atmospheric Influence Analysis:
+anomaly-scanner-atmosphere-none = Current State: [color=gray]No significant atmospheric influence[/color]
+anomaly-scanner-atmosphere-active = Current State: [color=white]{$gas}[/color] [color=gray]({$percent}%)[/color]
 
 gorilla-shove-not-disposals = You can only shove this into a disposals unit!
 gorilla-shove-gauntlet-not-active = The gauntlet isn't active!

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -48,6 +48,7 @@
     sound:
       path: /Audio/Effects/teleport_arrival.ogg
   - type: SecretDataAnomaly
+  - type: AnomalyGasConsumer # KS14
     randomStartSecretMin: 0
     randomStartSecretMax: 2
   - type: DamageOnInteract
@@ -65,6 +66,7 @@
   parent: BaseAnomaly
   suffix: Pyroclastic
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: AmbientSound
     volume: 5
     range: 5
@@ -124,6 +126,7 @@
   parent: BaseAnomaly
   suffix: Gravity
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Anomaly
     corePrototype: AnomalyCoreGravity
     coreInertPrototype: AnomalyCoreGravityInert
@@ -159,6 +162,7 @@
   parent: BaseAnomaly
   suffix: Electricity
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Anomaly
     corePrototype: AnomalyCoreElectricity
     coreInertPrototype: AnomalyCoreElectricityInert
@@ -184,6 +188,7 @@
   parent: BaseAnomaly
   suffix: Flesh
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Anomaly
     corePrototype: AnomalyCoreFlesh
     coreInertPrototype: AnomalyCoreFleshInert
@@ -279,6 +284,7 @@
   parent: BaseAnomaly
   suffix: Bluespace
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Sprite
     layers:
     - state: anom4
@@ -328,6 +334,7 @@
   parent: BaseAnomaly
   suffix: Ice
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Sprite
     sprite: Structures/Specific/Anomalies/ice_anom.rsi
     layers:
@@ -385,6 +392,7 @@
   abstract: true
   suffix: Rock
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Anomaly
     corePrototype: AnomalyCoreRock
     coreInertPrototype: AnomalyCoreRockInert
@@ -774,6 +782,7 @@
   parent: BaseAnomaly
   suffix: Flora
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Sprite
     drawdepth: Mobs
     sprite: Structures/Specific/Anomalies/flora_anom.rsi
@@ -876,6 +885,7 @@
   parent: BaseAnomaly
   suffix: Liquid
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Sprite
     sprite: Structures/Specific/Anomalies/liquid_anom.rsi
     layers:
@@ -996,6 +1006,7 @@
   parent: BaseAnomaly
   suffix: Shadow
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Sprite
     sprite: Structures/Specific/Anomalies/shadow_anom.rsi
     layers:
@@ -1060,6 +1071,7 @@
   parent: BaseAnomaly
   suffix: Tech
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Sprite
     sprite: Structures/Specific/Anomalies/tech_anom.rsi
     layers:
@@ -1122,6 +1134,7 @@
   parent: BaseAnomaly
   suffix: Santa
   components:
+  - type: AnomalyGasConsumer # KS14
   - type: Sprite
     drawdepth: Mobs
     sprite: Structures/Specific/Anomalies/santa_anom.rsi

--- a/Resources/Prototypes/_KS14/Atmospherics/anomaly_gas_effects.yml
+++ b/Resources/Prototypes/_KS14/Atmospherics/anomaly_gas_effects.yml
@@ -1,0 +1,58 @@
+- type: anomalyGasEffect
+  id: NitrogenEffect
+  gas: Nitrogen
+
+- type: anomalyGasEffect
+  id: PlasmaEffect
+  gas: Plasma
+  stabilityModifier: 0.02
+  pointMultiplier: 1.5
+
+- type: anomalyGasEffect
+  id: TritiumEffect
+  gas: Tritium
+  stabilityModifier: 0.05
+  severityModifier: 0.01
+  pointMultiplier: 2.5
+  pulseFrequencyMultiplier: 1.2
+  pulsePowerMultiplier: 1.5
+
+- type: anomalyGasEffect
+  id: FrezonEffect
+  gas: Frezon
+  stabilityModifier: -0.10
+  severityModifier: -0.07
+  pointMultiplier: 0.8
+  pulseFrequencyMultiplier: 0.8
+  pulsePowerMultiplier: 0.8
+
+- type: anomalyGasEffect
+  id: ArgonEffect
+  gas: Argon
+  stabilityModifier: -0.01
+  decayBuffer: 0.2
+  pointMultiplier: 0.5
+
+- type: anomalyGasEffect
+  id: AmmoniaEffect
+  gas: Ammonia
+  healthModifier: 0.01
+
+- type: anomalyGasEffect
+  id: CarbonDioxideEffect
+  gas: CarbonDioxide
+  healthModifier: -0.02
+  pulseFrequencyMultiplier: 0.5
+
+- type: anomalyGasEffect
+  id: ZipionEffect
+  gas: Zipion
+  stabilityModifier: 0.01
+  pointMultiplier: 1.2
+  pulseFrequencyMultiplier: 1.5
+  pulsePowerMultiplier: 1.2
+
+- type: anomalyGasEffect
+  id: NitrousOxideEffect
+  gas: NitrousOxide
+  pulsePowerMultiplier: 0.5


### PR DESCRIPTION
## What was changed
<!-- If changelog sufficiently describes your changes, you may omit this section -->
Implemented the **Anomaly Gas Interplay system** from the atmos design doc, allowing anomalies to dynamically react to the atmospheric composition of their environment. 
   * **Dual-Gas Interaction:** Anomalies now detect and consume the top two dominant gases in their tile (excluding Nitrogen).
   * **Data-Driven Effects:** Introduced AnomalyGasEffectPrototype to define how specific gases (Plasma, Tritium, Frezon, Argon, Ammonia, CO2, Zipion, N2O) modify an anomaly's Stability, Severity, Health, Point Generation, and Pulse behavior.
   * **Additive Stacking:** The Primary gas applies at full strength based on its partial pressure (scaling between 10 kPa and 500 kPa). The Secondary gas applies its effects additively, but with a configurable penalty (default 50% reduction).
   * **Admin Scanner UI:** Updated the Anomaly Scanner UI. When used by admins (or scanners with ignoreSecret), it now displays the exact Primary and Secondary catalysts, their saturation percentages, the anomaly's exact Health percentage, and debug multipliers.

## Why
Design doc

## Media
<img width="1569" height="759" alt="image" src="https://github.com/user-attachments/assets/f1cfd6df-e657-4dd1-9e89-a33df1a65e3e" />
<img width="1061" height="190" alt="image" src="https://github.com/user-attachments/assets/dac4b5a1-9e3c-455d-aeac-2f7b4ee2c8b2" />

## Requirements
- [X] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] Design doc

## Breaking changes
<!-- List any changes that might break future work -->
None. This relies on additive multipliers that default to 1.0/Neutral if an anomaly is in a standard Nitrogen/Oxygen mix or a vacuum.

**Changelog**
:cl: Gerkada
- add: Anomalies now dynamically react to and consume atmospheric gases, altering their point generation, stability, and pulse behavior based on the surrounding mix.
- add: The Anomaly Scanner can now detect atmospheric influences, displaying the Primary and Secondary gas catalysts affecting the anomaly.
- tweak: Admin anomaly scanners now display the exact Health percentage of an anomaly.


