### PR TITLE
[Design Doc] Add Evaporin gas

### DIFF
--- a/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
@@ -30,9 +30,10 @@ namespace Content.Server.Atmos.Portable
             Gas.Ammonia,
             Gas.NitrousOxide,
             Gas.Frezon,
-            Gas.Zipion
-        };
-
+            Gas.Zipion, // KS14
+            Gas.Argon, // KS14
+            Gas.Evaporin // KS14
+            };
         [ViewVariables(VVAccess.ReadWrite)]
         public bool Enabled = true;
 

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Fluids.Components;
 using Content.Server.Spreader;
+using Content.Shared.Atmos;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;

--- a/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
@@ -18,7 +18,9 @@ public sealed partial class GasLeakRuleComponent : Component
         Gas.Tritium,
         Gas.Frezon,
         Gas.WaterVapor, // the fog
-        Gas.Zipion // KS14 zipion
+        Gas.Zipion, // KS14 zipion
+        Gas.Argon, // KS14
+        Gas.Evaporin // KS14
     };
 
     /// <summary>

--- a/Content.Server/_KS14/Atmos/EntitySystems/EvaporinGasSystem.cs
+++ b/Content.Server/_KS14/Atmos/EntitySystems/EvaporinGasSystem.cs
@@ -1,0 +1,45 @@
+using Content.Server.Atmos.Portable;
+using Content.Shared._KS14.Atmos.Components;
+using Content.Server.Body.Systems;
+using Content.Shared.Atmos;
+using Content.Shared.Body;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Events;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._KS14.Atmos.EntitySystems;
+
+public sealed class EvaporinGasSystem : EntitySystem
+{
+    [Dependency] private readonly ThirstSystem _thirstSystem = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<EvaporinMetabolizerComponent, InhaledGasEvent>(OnGasInhaled);
+    }
+
+    private void OnGasInhaled(Entity<EvaporinMetabolizerComponent> ent, ref InhaledGasEvent args)
+    {
+        var moles = args.Gas.GetMoles(Gas.Evaporin);
+        if (moles <= Atmospherics.GasMinMoles)
+            return;
+
+        if (!TryComp<ThirstComponent>(ent, out var thirst))
+            return;
+
+        var bodyEntity = new Entity<ThirstComponent>(ent, thirst);
+
+        _thirstSystem.ModifyThirst(bodyEntity.Owner, bodyEntity.Comp, -moles * ent.Comp.ThirstMultiplier);
+
+        if (bodyEntity.Comp.CurrentThirstThreshold == ThirstThreshold.Dead)
+        {
+            // Scale damage by moles inhaled to make dense clouds more dangerous
+            _damageableSystem.TryChangeDamage(bodyEntity.Owner, ent.Comp.Damage * moles, true, false);
+        }
+    }
+}

--- a/Content.Server/_KS14/Atmos/Reactions/EvaporinSynthesisReaction.cs
+++ b/Content.Server/_KS14/Atmos/Reactions/EvaporinSynthesisReaction.cs
@@ -1,0 +1,59 @@
+using Content.Server.Atmos;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Reactions;
+using JetBrains.Annotations;
+
+namespace Content.Server._KS14.Atmos.Reactions;
+
+/// <summary>
+///     Synthesis of Evaporin from Tritium and Carbon Dioxide at high temperatures.
+/// </summary>
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class EvaporinSynthesisReaction : IGasReactionEffect
+{
+    public EvaporinSynthesisReaction() { }
+
+    public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
+    {
+        var temperature = mixture.Temperature;
+
+        // The reaction is most efficient EXACTLY at 500K.
+        // It drops off to 0 efficiency at 400K or 600K.
+        var efficiency = 1.0f - (Math.Abs(temperature - 500f) / 100f);
+
+        if (efficiency <= 0f) 
+            return ReactionResult.NoReaction;
+
+        var initialTrit = mixture.GetMoles(Gas.Tritium);
+        var initialCO2 = mixture.GetMoles(Gas.CarbonDioxide);
+
+        // Recipe: 1 part Tritium + 2 parts Carbon Dioxide
+        // We limit by the scarcest reagent according to the 1:2 ratio
+        var possibleByTrit = initialTrit;
+        var possibleByCO2 = initialCO2 / 2f;
+
+        var reactionMoles = Math.Min(possibleByTrit, possibleByCO2);
+
+        if (reactionMoles <= Atmospherics.GasMinMoles)
+            return ReactionResult.NoReaction;
+
+        // Rate limit the reaction. Base is 5% (1/20) per tick at max efficiency.
+        // Drops lower as temperature diverges from 500K.
+        var rateLimit = (reactionMoles / 20f) * efficiency; 
+
+        if (rateLimit <= Atmospherics.GasMinMoles)
+            return ReactionResult.NoReaction;
+
+        // Adjust reagents: -1 Trit, -2 CO2
+        mixture.AdjustMoles(Gas.Tritium, -rateLimit);
+        mixture.AdjustMoles(Gas.CarbonDioxide, -rateLimit * 2f);
+
+        // Products: +1 Evaporin, +1 Ammonia (byproduct)
+        mixture.AdjustMoles(Gas.Evaporin, rateLimit);
+        mixture.AdjustMoles(Gas.Ammonia, rateLimit);
+
+        return ReactionResult.Reacting;
+    }
+}

--- a/Content.Server/_KS14/Fluids/EntitySystems/PuddleSystem.Evaporin.cs
+++ b/Content.Server/_KS14/Fluids/EntitySystems/PuddleSystem.Evaporin.cs
@@ -1,0 +1,25 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos;
+using Content.Shared.FixedPoint;
+using Content.Shared.Fluids.Components;
+
+namespace Content.Server.Fluids.EntitySystems;
+
+public sealed partial class PuddleSystem
+{
+    [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+
+    protected override void ModifyEvaporationRate(Entity<PuddleComponent> puddle, ref FixedPoint2 evaporateRate)
+    {
+        if (_atmosphereSystem.GetTileMixture(puddle.Owner, true) is { } mixture)
+        {
+            var moles = mixture.GetMoles(Gas.Evaporin);
+            if (moles > Atmospherics.GasMinMoles)
+            {
+                // Add a flat rate scaled by moles, making it extremely fast
+                // e.g. 1 mole = 3.0 evaporation speed
+                evaporateRate += FixedPoint2.New(moles * puddle.Comp.EvaporinEvaporationMultiplier);
+            }
+        }
+    }
+}

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -223,7 +223,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Total number of gases. Increase this if you want to add more!
         /// </summary>
-        public const int TotalNumberOfGases = 11; // KS14 new gases: zipion, argon
+        public const int TotalNumberOfGases = 12; // KS14 new gases: zipion, argon, evaporin
 
         /// <summary>
         ///     This is the actual length of the gases arrays in mixtures.
@@ -389,5 +389,6 @@ namespace Content.Shared.Atmos
         Frezon = 8,
         Zipion = 9, //KS14
         Argon = 10, //KS14
+        Evaporin = 11, //KS14
     }
 }

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -24,8 +24,9 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Gas.Ammonia,
             Gas.NitrousOxide,
             Gas.Frezon,
-            Gas.Zipion,
-            Gas.Argon
+            Gas.Zipion, // KS14
+            Gas.Argon, // KS14
+            Gas.Evaporin // KS14
         };
 
         // Presets for 'dumb' air alarm modes

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -22,15 +22,13 @@ public abstract partial class SharedPuddleSystem
         if (_evaporationQuery.HasComp(uid))
             return;
 
-        if (solution.GetTotalPrototypeQuantity(GetEvaporatingReagents(solution)) > FixedPoint2.Zero)
-        {
-            var evaporation = AddComp<EvaporationComponent>(uid);
-            evaporation.NextTick = _timing.CurTime + EvaporationCooldown;
-            Dirty<EvaporationComponent>((uid, evaporation));
-            return;
-        }
-
-        RemComp<EvaporationComponent>(uid);
+        // KS14 - Start
+        // Always add EvaporationComponent so Evaporin gas can evaporate any puddle,
+        // even if it does not naturally evaporate.
+        var evaporation = AddComp<EvaporationComponent>(uid);
+        evaporation.NextTick = _timing.CurTime + EvaporationCooldown;
+        Dirty<EvaporationComponent>((uid, evaporation));
+        // KS14 - End
     }
 
     private void TickEvaporation()
@@ -52,18 +50,39 @@ public abstract partial class SharedPuddleSystem
             // If we have multiple evaporating reagents in one puddle, just take the average evaporation speed and apply
             // that to all of them.
             var evaporationSpeeds = GetEvaporationSpeeds(puddleSolution);
-            if (evaporationSpeeds.Count == 0)
+
+            // KS14 - Start
+            var baseEvaporationSpeed = evaporationSpeeds.Count > 0 ? evaporationSpeeds.Values.Sum() / evaporationSpeeds.Count : FixedPoint2.Zero;
+            var modifiedSpeed = baseEvaporationSpeed;
+
+            ModifyEvaporationRate((uid, puddle), ref modifiedSpeed);
+
+            if (modifiedSpeed <= FixedPoint2.Zero)
                 continue;
 
-            // Can't use .Average because FixedPoint2
-            var evaporationSpeed = evaporationSpeeds.Values.Sum() / evaporationSpeeds.Count;
-            var reagentProportions = evaporationSpeeds.ToDictionary(kv => kv.Key,
-                kv => puddleSolution.GetTotalPrototypeQuantity(kv.Key) / puddleSolution.Volume);
+            var evaporinForced = modifiedSpeed > baseEvaporationSpeed;
+            Dictionary<ProtoId<ReagentPrototype>, FixedPoint2> reagentProportions;
+
+            if (evaporinForced)
+            {
+                // Evaporin is present: force evaporation of the ENTIRE puddle, regardless of contents.
+                reagentProportions = puddleSolution.Contents.ToDictionary(
+                    r => new ProtoId<ReagentPrototype>(r.Reagent.Prototype), 
+                    r => r.Quantity / puddleSolution.Volume);
+            }
+            else
+            {
+                // Vanilla behavior: only evaporate naturally evaporating reagents.
+                reagentProportions = evaporationSpeeds.ToDictionary(
+                    kv => kv.Key, 
+                    kv => puddleSolution.GetTotalPrototypeQuantity(kv.Key) / puddleSolution.Volume);
+            }
+            // KS14 - End
 
             // Still have to iterate over one-by-one since the full solution could have non-evaporating solutions.
             foreach (var (reagent, factor) in reagentProportions)
             {
-                var reagentTick = evaporation.EvaporationAmount * EvaporationCooldown.TotalSeconds * evaporationSpeed * factor;
+                var reagentTick = evaporation.EvaporationAmount * EvaporationCooldown.TotalSeconds * modifiedSpeed * factor;
                 puddleSolution.SplitSolutionWithOnly(reagentTick, reagent);
             }
 

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -17,17 +17,30 @@ public abstract partial class SharedPuddleSystem
         Dirty(ent);
     }
 
-    private void UpdateEvaporation(EntityUid uid, Solution solution)
+    private void UpdateEvaporation(Entity<PuddleComponent> entity, Solution solution)
     {
-        if (_evaporationQuery.HasComp(uid))
-            return;
-
         // KS14 - Start
-        // Always add EvaporationComponent so Evaporin gas can evaporate any puddle,
-        // even if it does not naturally evaporate.
-        var evaporation = AddComp<EvaporationComponent>(uid);
-        evaporation.NextTick = _timing.CurTime + EvaporationCooldown;
-        Dirty<EvaporationComponent>((uid, evaporation));
+        // Calculate evaporation speed, including dynamic modifications (e.g. Evaporin gas).
+        var speeds = GetEvaporationSpeeds(solution);
+        var baseSpeed = speeds.Count > 0 ? speeds.Values.Sum() / speeds.Count : FixedPoint2.Zero;
+        var modifiedSpeed = baseSpeed;
+
+        ModifyEvaporationRate(entity, ref modifiedSpeed);
+
+        if (modifiedSpeed > FixedPoint2.Zero)
+        {
+            if (!_evaporationQuery.HasComp(entity))
+            {
+                var evaporation = AddComp<EvaporationComponent>(entity);
+                evaporation.NextTick = _timing.CurTime + EvaporationCooldown;
+                Dirty(entity.Owner, evaporation);
+            }
+        }
+        else
+        {
+            if (_evaporationQuery.HasComp(entity))
+                RemComp<EvaporationComponent>(entity);
+        }
         // KS14 - End
     }
 

--- a/Content.Shared/_KS14/Atmos/Components/EvaporinMetabolizerComponent.cs
+++ b/Content.Shared/_KS14/Atmos/Components/EvaporinMetabolizerComponent.cs
@@ -1,0 +1,31 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._KS14.Atmos.Components;
+
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class EvaporinMetabolizerComponent : Component
+{
+    /// <summary>
+    /// How much thirst is subtracted per mole of Evaporin inhaled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ThirstMultiplier = 1000000f; // Evaporin is VERY drying.
+
+    /// <summary>
+    /// Damage dealt when the entity is completely thirsty AND inhaling Evaporin.
+    /// Scaled by moles inhaled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier Damage = new()
+    {
+        DamageDict = new Dictionary<ProtoId<DamageTypePrototype>, FixedPoint2>
+        {
+            { "Poison", FixedPoint2.New(500) } // High value because it's multiplied by moles (which are small in a breath)
+        }
+    };
+}

--- a/Content.Shared/_KS14/Atmos/Components/GasGrenadeCompressorComponent.cs
+++ b/Content.Shared/_KS14/Atmos/Components/GasGrenadeCompressorComponent.cs
@@ -60,7 +60,8 @@ public sealed partial class GasGrenadeCompressorComponent : Component
         Gas.WaterVapor,
         Gas.Ammonia,
         Gas.Zipion,
-        Gas.Argon
+        Gas.Argon,
+        Gas.Evaporin
     };
 }
 

--- a/Content.Shared/_KS14/EntityEffects/Effects/Body/EvaporinDehydrationDamage.cs
+++ b/Content.Shared/_KS14/EntityEffects/Effects/Body/EvaporinDehydrationDamage.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.EntityEffects;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._KS14.EntityEffects.Effects.Body;
+
+/// <summary>
+/// Deals damage if the entity is at the Dead thirst threshold.
+/// </summary>
+public sealed partial class EvaporinDehydrationDamage : EntityEffectBase<EvaporinDehydrationDamage>
+{
+    [DataField(required: true)]
+    public DamageSpecifier Damage = default!;
+}
+
+public sealed partial class EvaporinDehydrationDamageSystem : EntityEffectSystem<ThirstComponent, EvaporinDehydrationDamage>
+{
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+
+    protected override void Effect(Entity<ThirstComponent> entity, ref EntityEffectEvent<EvaporinDehydrationDamage> args)
+    {
+        if (entity.Comp.CurrentThirstThreshold != ThirstThreshold.Dead)
+            return;
+
+        _damageableSystem.TryChangeDamage(entity.Owner, args.Effect.Damage * args.Scale, true, false);
+    }
+}

--- a/Content.Shared/_KS14/Fluids/Components/PuddleComponent.Evaporin.cs
+++ b/Content.Shared/_KS14/Fluids/Components/PuddleComponent.Evaporin.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.Fluids.Components;
+
+public sealed partial class PuddleComponent
+{
+    [DataField]
+    public float EvaporinEvaporationMultiplier = 3.0f;
+}

--- a/Content.Shared/_KS14/Fluids/SharedPuddleSystem.Evaporin.cs
+++ b/Content.Shared/_KS14/Fluids/SharedPuddleSystem.Evaporin.cs
@@ -1,0 +1,9 @@
+using Content.Shared.FixedPoint;
+using Content.Shared.Fluids.Components;
+
+namespace Content.Shared.Fluids;
+
+public abstract partial class SharedPuddleSystem
+{
+    protected virtual void ModifyEvaporationRate(Entity<PuddleComponent> puddle, ref FixedPoint2 evaporateRate) { }
+}

--- a/Resources/Locale/en-US/_KS14/atmos/evaporin.ftl
+++ b/Resources/Locale/en-US/_KS14/atmos/evaporin.ftl
@@ -1,0 +1,6 @@
+gas-evaporin-abbreviation = Ev
+gases-evaporin = Evaporin
+
+reagent-name-evaporin = Evaporin
+reagent-desc-evaporin = A highly volatile gas that extracts moisture from its surroundings. Extremely dehydrating if inhaled.
+reagent-physical-desc-evaporin = shimmering haze

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -176,6 +176,7 @@
   components:
   - type: Hunger
   - type: Thirst
+  - type: EvaporinMetabolizer # KS14
   - type: Barotrauma
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -16,6 +16,9 @@
     - Ammonia
     - NitrousOxide
     - Frezon
+    - Zipion # KS14
+    - Argon # KS14
+    - Evaporin # KS14
     #- Helium3 TODO: fusion
     # remove everything except oxygen to maintain oxygen ratio
     overflowGases:
@@ -27,8 +30,11 @@
     - Ammonia
     - NitrousOxide
     - Frezon
-    - Zipion
+    - Zipion # KS14
+    - Argon # KS14
+    - Evaporin # KS14
     #- Helium3 TODO: fusion
+
   - type: AirIntake
   # for intake and filter to work
   - type: AtmosDevice

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -25,8 +25,9 @@
       Ammonia: stationAmmonia
       NitrousOxide: stationNO
       Frezon: danger
-      Zipion: stationZipion
-      Argon: GasArgon
+      Zipion: stationZipion # KS14
+      Argon: GasArgon # KS14
+      Evaporin: stationEvaporin # KS14
   - type: Tag
     tags:
       - AirSensor

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -15,7 +15,7 @@
       Ammonia: stationAmmonia
       NitrousOxide: stationNO
       Frezon: danger
-      Zipion: stationZipion
+      Zipion: stationZipion # KS14
 
 - type: entity
   parent: [AirSensorVoxBase, AirSensor]
@@ -40,6 +40,9 @@
     - Ammonia
     - NitrousOxide
     - Frezon
+    - Zipion # KS14
+    - Argon # KS14
+    - Evaporin # KS14
 
 # use this to prevent overriding filters with hardcoded defaults
 - type: entity

--- a/Resources/Prototypes/Paintables/canister_groups.yml
+++ b/Resources/Prototypes/Paintables/canister_groups.yml
@@ -14,5 +14,6 @@
     storage: StorageCanister
     tritium: TritiumCanister
     water-vapor: WaterVaporCanister
-    zipion: ZipionCanister
-    argon: ArgonCanister
+    zipion: ZipionCanister # KS14
+    argon: ArgonCanister # KS14
+    evaporin: EvaporinCanister # KS14

--- a/Resources/Prototypes/_KS14/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/_KS14/Atmospherics/Thresholds/airalarms.yml
@@ -11,3 +11,10 @@
     threshold: 0.01
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.1 # 0.001 / 0.01
+
+- type: alarmThreshold # KS14
+  id: stationEvaporin
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.01
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.5

--- a/Resources/Prototypes/_KS14/Atmospherics/evaporin.yml
+++ b/Resources/Prototypes/_KS14/Atmospherics/evaporin.yml
@@ -1,0 +1,10 @@
+- type: gas
+  id: Evaporin
+  name: gases-evaporin
+  abbreviation: gas-evaporin-abbreviation
+  molarHeatCapacity: 40
+  heatCapacityRatio: 1.4
+  molarMass: 60
+  color: '#e0e0ff08' # Translucent light blue/white
+  reagent: Evaporin
+  pricePerMole: 2.5

--- a/Resources/Prototypes/_KS14/Atmospherics/evaporin_reaction.yml
+++ b/Resources/Prototypes/_KS14/Atmospherics/evaporin_reaction.yml
@@ -1,0 +1,9 @@
+- type: gasReaction
+  id: EvaporinSynthesis
+  priority: 500
+  minimumTemperature: 400
+  minimumRequirements:
+    Tritium: 0.1
+    CarbonDioxide: 0.1
+  effects:
+    - !type:EvaporinSynthesisReaction {}

--- a/Resources/Prototypes/_KS14/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/_KS14/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -102,6 +102,57 @@
   - type: Lock
     locked: true
 
+- type: entity # KS14
+  parent: GasCanister
+  id: EvaporinCanister
+  name: evaporin canister
+  description: A canister that can contain any type of gas. This one is supposed to contain evaporin. It can be attached to connector ports using a wrench.
+  components:
+  - type: Sprite
+    layers:
+    - state: multi_shader
+      color: "#e0e0ff"
+    - state: double_stripe
+      color: "#ffffff"
+    - state: outline
+      color: "#e0e0ff"
+    - state: window-base
+    - state: paper
+      visible: false
+      map: [ "enum.PaperLabelVisuals.Layer" ]
+      sprite: Structures/Storage/canister.rsi # use upstream sprite
+  - type: GasCanister
+    air:
+      volume: 1500
+      moles:
+        Evaporin: 2769.36
+      temperature: 293.15
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          EvaporinCanisterBroken:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:DumpCanisterBehavior
+  - type: Lock
+    locked: true
+
 ## Broken
 
 - type: entity
@@ -133,3 +184,18 @@
       color: "#990685"
     - state: outline_broken
       color: "#00d5ff"
+
+- type: entity # KS14
+  parent: GasCanisterBrokenBase
+  id: EvaporinCanisterBroken
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - state: window-base_broken
+    - state: multi_shader_broken
+      color: "#e0e0ff"
+    - state: double_stripe_broken
+      color: "#ffffff"
+    - state: outline_broken
+      color: "#e0e0ff"

--- a/Resources/Prototypes/_KS14/Reagents/evaporin.yml
+++ b/Resources/Prototypes/_KS14/Reagents/evaporin.yml
@@ -1,0 +1,23 @@
+- type: reagent
+  id: Evaporin
+  name: reagent-name-evaporin
+  desc: reagent-desc-evaporin
+  physicalDesc: reagent-physical-desc-evaporin
+  color: "#e0e0ff"
+  metabolisms:
+    Digestion:
+      effects:
+      - !type:SatiateThirst
+        factor: -8.0 # Extremely dehydrating
+      - !type:EvaporinDehydrationDamage
+        damage:
+          types:
+            Poison: 5.0
+    Bloodstream:
+      effects:
+      - !type:SatiateThirst
+        factor: -8.0
+      - !type:EvaporinDehydrationDamage
+        damage:
+          types:
+            Poison: 5.0


### PR DESCRIPTION
## What was changed
<!-- If changelog sufficiently describes your changes, you may omit this section -->
   * **New Content:** Added Evaporin as both a gas and a liquid reagent.
   * **Synthesis:** Implemented a high-temperature synthesis reaction for Evaporin ($2:1$ Carbon Dioxide to Tritium ratio at 500K), which also yields Ammonia as a valuable byproduct.
   * **Puddle Overhaul:** Modified `SharedPuddleSystem` to allow "forced evaporation." Puddles on a tile with Evaporin gas now evaporate at a massive flat rate, regardless of whether the liquid is naturally evaporating (e.g., blood, water, and oil now vanish rapidly).
   * **Biological Effects:** Inhaling gaseous Evaporin or ingesting it as a liquid causes extreme dehydration (negative thirst). If the victim is already "Parched" ($0$ thirst), Evaporin deals continuous Poison damage.
   * **Infrastructure:** 
       * Added full support for Evaporin in **Air Alarms**, atmospheric sensors etc.
       * Updated **Scrubbers** (fixed and portable) to filter Evaporin, Zipion, and Argon by default.
       * Created the **Evaporin Gas Canister** (functional and broken) and added it to the paintable group.
       * Added Evaporin to the **Air Grenade Compressor** whitelist.

## Why
Fulfills the design requirement for the "Thinking Janitor’s alternative to cleanades." It provides a high-skill atmospheric utility that cleans the station while introducing a unique biological hazard and a new synthesis path for Ammonia.

## Media
<img width="811" height="596" alt="image" src="https://github.com/user-attachments/assets/e02180b7-1e20-4913-8b39-3f1dedfba63c" />

## Requirements
- [X] Tested, works.
- [X] I have added media to this PR, or it does not require an in-game showcase.
- [X] Design doc

## Breaking changes
<!-- List any changes that might break future work -->
**`SharedPuddleSystem`:** Puddles now receive an `EvaporationComponent` by default to allow external systems to modify their evaporation rate. This does not make them evaporate naturally unless a speed modifier is applied.

**Changelog**
:cl: Gerkada
- add: Added Evaporin gas and liquid reagent.
- add: Added Evaporin synthesis reaction (2 CO2 + 1 Tritium at 500K).
- add: Added Evaporin gas canister and paintable style.
- tweak: Puddles now evaporate significantly faster when exposed to Evaporin gas.
- tweak: Inhaling or ingesting Evaporin causes severe dehydration and poison damage when thirsty.
- tweak: Air alarms and scrubbers now support filtering Evaporin, Zipion, and Argon by default.
- fix: Fixed an issue where mixed puddles (e.g., water and blood) would only partially evaporate.