### PR TITLE
new scenario objectives

### DIFF
--- a/Content.Server/_KS14/GameTicking/Rules/ScenarioSystem.cs
+++ b/Content.Server/_KS14/GameTicking/Rules/ScenarioSystem.cs
@@ -11,6 +11,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
 using Content.Shared.Destructible;
 using System.Linq;
+using Content.Shared.Trigger.Systems;
+using Content.Shared.Trigger;
 
 namespace Content.Server._KS14.GameTicking.Rules;
 
@@ -23,6 +25,7 @@ public sealed partial class ScenarioRuleComponent : Component
 public sealed class ScenarioSystem : GameRuleSystem<ScenarioRuleComponent>
 {
     [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
+    [Dependency] private readonly TriggerSystem _triggerSystem = default!;
 
     public override void Initialize()
     {
@@ -38,6 +41,7 @@ public sealed class ScenarioSystem : GameRuleSystem<ScenarioRuleComponent>
         SubscribeLocalEvent<ScenarioNtComponent, MobStateChangedEvent>(OnNtMobstateChanged);
         SubscribeLocalEvent<ScenarioNtComponent, EntityZombifiedEvent>(OnNtZombified);
 
+        SubscribeLocalEvent<ScenarioObjectiveComponent, TriggerEvent>(OnTriggered);
         SubscribeLocalEvent<ScenarioObjectiveComponent, TimedDespawnEvent>(OnObjDefended);
         SubscribeLocalEvent<ScenarioObjectiveComponent, DestructionEventArgs>(OnObjDestroyed);
 
@@ -154,17 +158,26 @@ public sealed class ScenarioSystem : GameRuleSystem<ScenarioRuleComponent>
 
     }
 
+    private void OnTriggered(Entity<ScenarioObjectiveComponent> entity, ref TriggerEvent args)
+    {
+        if (args.Key is { } key &&
+            !entity.Comp.KeysIn.Contains(key))
+            return;
+
+        WinThruObjective();
+    }
+
     private void OnObjDefended(EntityUid uid, ScenarioObjectiveComponent component, TimedDespawnEvent args)
     {
-        SetWinType(true);
-        _roundEndSystem.DoRoundEndBehavior(RoundEndBehavior.InstantEnd,
-            TimeSpan.FromMinutes(3), //doesnt matter
-            "comms-console-announcement-title-centcom",
-            "comms-console-announcement-title-centcom",
-            "comms-console-announcement-title-centcom");
+        WinThruObjective();
     }
 
     private void OnObjDestroyed(EntityUid uid, ScenarioObjectiveComponent component, DestructionEventArgs args)
+    {
+        WinThruObjective();
+    }
+
+    private void WinThruObjective()
     {
         SetWinType(true);
         _roundEndSystem.DoRoundEndBehavior(RoundEndBehavior.InstantEnd,

--- a/Content.Shared/_KS14/Scenario/Components/ScenarioObjectiveComponent.cs
+++ b/Content.Shared/_KS14/Scenario/Components/ScenarioObjectiveComponent.cs
@@ -10,4 +10,11 @@ public sealed partial class ScenarioObjectiveComponent : Component
 {
     [DataField("isNt")] //literally what it says on the tin
     public bool isNt = false;
+
+    // ffs
+    /// <summary>
+    ///     Trigger keys to trigger a win.
+    /// </summary>
+    [DataField]
+    public HashSet<string> KeysIn = [];
 }

--- a/Content.Shared/_KS14/Trigger/Components/AnnouncementOnTriggerComponent.cs
+++ b/Content.Shared/_KS14/Trigger/Components/AnnouncementOnTriggerComponent.cs
@@ -1,0 +1,35 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager.Definition;
+
+namespace Content.Shared._KS14.Trigger.Components;
+
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class AnnouncementOnTriggerComponent : Component
+{
+    /// <summary>
+    ///     When receiving a key, will do the corresponding
+    ///         announcement.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, AnnouncementOnTriggerDatum> AnnouncementsPerKey = [];
+}
+
+[Serializable, NetSerializable]
+[DataDefinition]
+public sealed partial class AnnouncementOnTriggerDatum
+{
+    [DataField(required: true)]
+    public LocId AnnouncementLoc;
+
+    [DataField]
+    public LocId? SenderLoc = null;
+
+    [DataField]
+    public Color? ColorOverride = null;
+
+    [DataField]
+    public SoundSpecifier? Sound = null;
+}

--- a/Content.Shared/_KS14/Trigger/Components/DoAfterOnTriggerComponent.cs
+++ b/Content.Shared/_KS14/Trigger/Components/DoAfterOnTriggerComponent.cs
@@ -1,0 +1,64 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Trigger.Components.Effects;
+using Content.Shared.Trigger.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._KS14.Trigger.Components;
+
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState(fieldDeltas: true), AutoGenerateComponentPause]
+public sealed partial class DoAfterOnTriggerComponent : BaseXOnTriggerComponent
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan Duration;
+
+    [DataField, AutoNetworkedField]
+    public string? StartKeyOut = null;
+
+    [DataField, AutoNetworkedField]
+    public string? CancelledKeyOut = null;
+
+    [DataField, AutoNetworkedField]
+    public string? KeyOut = TriggerSystem.DefaultTriggerKey;
+
+    // Cooldown
+
+    [DataField, AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextAllowedTime = TimeSpan.MinValue;
+
+    /// <summary>
+    ///     Cooldown between attempts to start the doafter.
+    ///         If zero, then the cooldown does not apply.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan Cooldown = TimeSpan.Zero;
+
+    /// <summary>
+    ///     If not null, then this popup will be shown to the user
+    ///         when they try to do a do-after, but the cooldown has not passed.
+    ///
+    ///     This gets a param called `time` which is the number of seconds (with 1 digit of decimal at most)
+    ///          left until the cooldown expires.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId? CooldownPopupLoc = null;
+
+    // Max users
+
+    /// <summary>
+    ///     If true, no new do-afters can be started when one is ongoing.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BlockDuplicate = false;
+
+    /// <summary>
+    ///     If not null, then this popup will be shown to the user
+    ///         when they try to do a do-after, but their is already someone
+    ///         using this and <see cref="BlockDuplicate"/> is true.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId? DuplicatePopupLoc = null;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? CurrentUserUid = null;
+}

--- a/Content.Shared/_KS14/Trigger/Components/SparkOnTriggerComponent.cs
+++ b/Content.Shared/_KS14/Trigger/Components/SparkOnTriggerComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
-namespace Content.Shared._KS14.Trigger.Components.Effects;
+namespace Content.Shared._KS14.Trigger.Components;
 
 // TODO: Hotspot-expose
 /// <summary>
@@ -38,4 +38,3 @@ public sealed partial class SparkOnTriggerComponent : BaseXOnTriggerComponent
     [DataField]
     public SoundSpecifier? SoundSpecifier = null;
 }
-

--- a/Content.Shared/_KS14/Trigger/Systems/AnnouncementOnTriggerSystem.cs
+++ b/Content.Shared/_KS14/Trigger/Systems/AnnouncementOnTriggerSystem.cs
@@ -1,0 +1,38 @@
+using Content.Shared._KS14.Trigger.Components;
+using Content.Shared.Chat;
+using Content.Shared.Trigger;
+
+namespace Content.Shared._KS14.Trigger.Systems;
+
+public sealed class AnnouncementOnTriggerSystem : EntitySystem
+{
+    [Dependency] private readonly SharedChatSystem _chatSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AnnouncementOnTriggerComponent, TriggerEvent>(OnTrigger);
+    }
+
+    private void OnTrigger(Entity<AnnouncementOnTriggerComponent> entity, ref TriggerEvent args)
+    {
+        if (args.Key is not { } key ||
+            !entity.Comp.AnnouncementsPerKey.TryGetValue(key, out var announcementDatum))
+            return;
+
+        var sender = announcementDatum.SenderLoc is { } senderLoc ?
+            Loc.GetString(senderLoc) :
+            null;
+
+        _chatSystem.DispatchGlobalAnnouncement(
+            Loc.GetString(announcementDatum.AnnouncementLoc),
+            sender,
+            playSound: announcementDatum.Sound is { },
+            announcementSound: announcementDatum.Sound,
+            colorOverride: announcementDatum.ColorOverride
+        );
+
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/_KS14/Trigger/Systems/DoAfterOnTriggerSystem.cs
+++ b/Content.Shared/_KS14/Trigger/Systems/DoAfterOnTriggerSystem.cs
@@ -1,0 +1,99 @@
+using Content.Shared._KS14.Trigger.Components;
+using Content.Shared.DoAfter;
+using Content.Shared.Popups;
+using Content.Shared.Trigger;
+using Content.Shared.Trigger.Systems;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._KS14.Trigger.Systems;
+
+public sealed class DoAfterOnTriggerSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly TriggerSystem _triggerSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DoAfterOnTriggerComponent, TriggerEvent>(OnTrigger);
+        SubscribeLocalEvent<DoAfterOnTriggerComponent, DoAfterOnTriggerDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnTrigger(Entity<DoAfterOnTriggerComponent> entity, ref TriggerEvent args)
+    {
+        if (args.Key is { } key &&
+            !entity.Comp.KeysIn.Contains(key))
+            return;
+
+        if (entity.Comp.CurrentUserUid is { } currentUserUid &&
+            entity.Comp.BlockDuplicate &&
+            currentUserUid != args.User)
+        {
+            if (args.User is { } userUid &&
+                entity.Comp.DuplicatePopupLoc is { } duplicatePopupLoc)
+                _popupSystem.PopupClient(Loc.GetString(duplicatePopupLoc), userUid, userUid);
+
+            return;
+        }
+
+        var curTime = _gameTiming.CurTime;
+        if (entity.Comp.NextAllowedTime > curTime)
+        {
+            if (args.User is { } userUid &&
+                entity.Comp.CooldownPopupLoc is { } cooldownPopupLoc)
+            {
+                var timeLeftSeconds = (float)(entity.Comp.NextAllowedTime - curTime).TotalSeconds;
+                _popupSystem.PopupClient(Loc.GetString(cooldownPopupLoc, ("time", $"{timeLeftSeconds:0.#}")), userUid, userUid);
+            }
+
+            return;
+        }
+
+        if (entity.Comp.TargetUser &&
+            args.User is not { })
+            return;
+
+        var doerUid = args.User ?? entity.Owner;
+        var ev = new DoAfterOnTriggerDoAfterEvent();
+        if (!_doAfterSystem.TryStartDoAfter(
+            new DoAfterArgs(EntityManager, doerUid, entity.Comp.Duration, ev, entity, target: entity)
+            { BlockDuplicate = entity.Comp.BlockDuplicate, DuplicateCondition = DuplicateConditions.SameTarget | DuplicateConditions.SameEvent }))
+            return;
+
+        entity.Comp.CurrentUserUid = args.User;
+        DirtyField(entity!, nameof(entity.Comp.CurrentUserUid));
+
+        entity.Comp.NextAllowedTime = curTime + entity.Comp.Cooldown;
+        DirtyField(entity!, nameof(entity.Comp.NextAllowedTime));
+
+        if (entity.Comp.StartKeyOut is { })
+            _triggerSystem.Trigger(entity, user: args.User, key: entity.Comp.StartKeyOut, predicted: true);
+
+        args.Handled = true;
+        args.Predicted = true;
+    }
+
+    private void OnDoAfter(Entity<DoAfterOnTriggerComponent> entity, ref DoAfterOnTriggerDoAfterEvent args)
+    {
+        entity.Comp.CurrentUserUid = null;
+        DirtyField(entity!, nameof(entity.Comp.CurrentUserUid));
+
+        if (args.Cancelled)
+        {
+            _triggerSystem.Trigger(entity, user: args.User, key: entity.Comp.CancelledKeyOut, predicted: true);
+            return;
+        }
+
+        _triggerSystem.Trigger(entity, user: args.User, key: entity.Comp.KeyOut, predicted: true);
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed partial class DoAfterOnTriggerDoAfterEvent : DoAfterEvent
+{
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/_KS14/Trigger/Systems/SparkOnTriggerSystem.cs
+++ b/Content.Shared/_KS14/Trigger/Systems/SparkOnTriggerSystem.cs
@@ -1,7 +1,8 @@
-using Content.Shared._KS14.Trigger.Components.Effects;
+using Content.Shared._KS14.Sparks;
+using Content.Shared._KS14.Trigger.Components;
 using Content.Shared.Trigger;
 
-namespace Content.Shared._KS14.Sparks;
+namespace Content.Shared._KS14.Trigger.Systems;
 
 public sealed class SparkOnTriggerSystem : EntitySystem
 {

--- a/Resources/Locale/en-US/_KS14/scenarios/objective.ftl
+++ b/Resources/Locale/en-US/_KS14/scenarios/objective.ftl
@@ -1,0 +1,6 @@
+ks-scenario-objective-announcement-capturestarted = The objective is being captured! It must be defended at all costs.
+ks-scenario-objective-announcement-captureended = The objective is no longer being captured.
+ks-scenario-objective-announcement-capturewin = The objective has been captured!
+
+ks-scenario-objective-popup-cooldown = You need to wait {$time} seconds before trying to capture this again!
+ks-scenario-objective-popup-oneuser = Someone is already capturing this!

--- a/Resources/Prototypes/_KS14/scenarios/structures.yml
+++ b/Resources/Prototypes/_KS14/scenarios/structures.yml
@@ -88,14 +88,89 @@
     sprite: Structures/Doors/Airlocks/Standard/maint.rsi
 
 - type: entity
-  parent: TelecomServer
+  parent: BaseStructure
   id: KsScenarioObjectiveSyndie
   name: syndicate objective
   description: This is a server that is of paramount importance to the syndicate. Would be a shame if someone broke it!
   components:
+  - type: Sprite
+    sprite: Structures/Machines/telecomms.rsi
+    snapCardinals: true
+    layers:
+    - state: telecom-nopower
+    - state: telecom-stripe
+    - state: telecom-on
+      shader: unshaded
+      map: ["onstate"]
+    - state: variant-sec
+      shader: unshaded
+      map: ["variant"]
+  - type: Clickable
+  - type: EmissiveLayers
+    glowRadius: 0.5
+    layers:
+    - onstate
+    - variant
   - type: ScenarioObjective
+    keysIn:
+    - win
   - type: TimedDespawn
     lifetime: 1800
+  - type: TriggerOnActivate
+  - type: DoAfterOnTrigger
+    duration: 15s
+    startKeyOut: started
+    cancelledKeyOut: cancelled
+    keyOut: win
+    blockDuplicate: true
+    duplicatePopupLoc: ks-scenario-objective-popup-oneuser
+    cooldown: 5s
+    cooldownPopupLoc: ks-scenario-objective-popup-cooldown
+  - type: DeleteOnTrigger
+    keysIn:
+    - win
+  - type: AnnouncementOnTrigger
+    announcementsPerKey:
+      started:
+        announcementLoc: ks-scenario-objective-announcement-capturestarted
+        colorOverride: Crimson
+        sound:
+          path: /Audio/Effects/Grenades/Supermatter/smbeep.ogg
+          params:
+            pitch: 0.5
+      cancelled:
+        announcementLoc: ks-scenario-objective-announcement-captureended
+        colorOverride: DarkGreen
+        sound:
+          path: /Audio/Misc/cryo_warning.ogg
+          params:
+            pitch: 0.5
+      win:
+        announcementLoc: ks-scenario-objective-announcement-capturewin
+        colorOverride: Cyan
+        sound:
+          path: /Audio/Announcements/war.ogg
+          params:
+            pitch: 0.5
+
+- type: entity
+  parent: KsScenarioObjectiveSyndie
+  id: KsScenarioObjectiveNanotrasen
+  name: nanotrasen objective
+  description: This is a server that is of paramount importance to Nanotrasen. Would be a shame if someone broke it!
+  components:
+  - type: Sprite
+    layers:
+    - state: telecom-nopower
+    - state: telecom-stripe
+    - state: telecom-on
+      shader: unshaded
+      map: ["onstate"]
+    - state: variant-multiple
+      shader: unshaded
+      map: ["variant"]
+  - type: ScenarioObjective
+    isNt: true
 
 - type: entity
   parent: MarkerBase


### PR DESCRIPTION
## What was changed
Scenario objectives now need a doafter
Old version of these was kinda ass because all you needed to do was destroy it which was not engaging gameplay

https://github.com/user-attachments/assets/f4e31397-7d9d-46ee-836d-71a3dfab8a1e


**Changelog**
:cl:
- remove: Scenario objectives are no longer damageable/destructible.
- tweak: Scenario objectives must now be clicked and have a 15-second doafter finish before it can be captured. Only one person can do this at a time.