### PR TITLE
Add more material solidification reactions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -439,7 +439,7 @@
         - ReagentId: Uranium
           Quantity: 8
         - ReagentId: Radium
-          Quantity: 8
+          Quantity: 2
         - ReagentId: Iron
           Quantity: 4.5
         - ReagentId: Carbon

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -385,7 +385,9 @@
         - ReagentId: Silicon
           Quantity: 10
         - ReagentId: Uranium
-          Quantity: 10
+          Quantity: 8
+        - ReagentId: Radium
+          Quantity: 2
         canReact: false
 
 - type: entity
@@ -435,7 +437,9 @@
         - ReagentId: Silicon
           Quantity: 10
         - ReagentId: Uranium
-          Quantity: 10
+          Quantity: 8
+        - ReagentId: Radium
+          Quantity: 8
         - ReagentId: Iron
           Quantity: 4.5
         - ReagentId: Carbon

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -174,31 +174,32 @@
     - !type:SpawnEntity
       entity: MaterialGunpowder
 
-- type: reaction
-  id: SolidifyGold
-  impact: Low
-  quantized: true
-  reactants:
-    Gold:
-      amount: 10
-    FrostOil:
-      amount: 5
-  effects:
-  - !type:SpawnEntity
-    entity: IngotGold1
-
-- type: reaction
-  id: SolidifySilver
-  impact: Low
-  quantized: true
-  reactants:
-    Silver:
-      amount: 10
-    FrostOil:
-      amount: 5
-  effects:
-  - !type:SpawnEntity
-    entity: IngotSilver1
+# KS14: moved to Resources/Prototypes/_KS14/Recipes/Reactions/solidification.yml
+# - type: reaction
+#   id: SolidifyGold
+#   impact: Low
+#   quantized: true
+#   reactants:
+#     Gold:
+#       amount: 10
+#     FrostOil:
+#       amount: 5
+#   effects:
+#   - !type:SpawnEntity
+#     entity: IngotGold1
+#
+# - type: reaction
+#   id: SolidifySilver
+#   impact: Low
+#   quantized: true
+#   reactants:
+#     Silver:
+#       amount: 10
+#     FrostOil:
+#       amount: 5
+#   effects:
+#   - !type:SpawnEntity
+#     entity: IngotSilver1
 
 - type: reaction
   id: WehHewExplosion

--- a/Resources/Prototypes/_KS14/Recipes/Reactions/food.yml
+++ b/Resources/Prototypes/_KS14/Recipes/Reactions/food.yml
@@ -7,6 +7,6 @@
     FrostOil:
       amount: 10
   products:
-    Nutriment: 6
+    Fat: 6
     Fresium: 3
     Protein: 1

--- a/Resources/Prototypes/_KS14/Recipes/Reactions/food.yml
+++ b/Resources/Prototypes/_KS14/Recipes/Reactions/food.yml
@@ -1,0 +1,12 @@
+- type: reaction
+  id: FrostOilBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    FrostOil:
+      amount: 10
+  products:
+    Nutriment: 6
+    Fresium: 3
+    Protein: 1

--- a/Resources/Prototypes/_KS14/Recipes/Reactions/solidification.yml
+++ b/Resources/Prototypes/_KS14/Recipes/Reactions/solidification.yml
@@ -1,0 +1,226 @@
+- type: reaction
+  id: SolidifySteel
+  impact: Low
+  quantized: true
+  reactants:
+    Iron:
+      amount: 9
+    Carbon:
+      amount: 1
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetSteel1
+
+- type: reaction
+  id: SolidifyPlasteel
+  impact: Low
+  quantized: true
+  priority: 1 # higher priority than SolidifySteel and SolidifyPlasma
+  reactants:
+    Plasma:
+      amount: 10
+    Iron:
+      amount: 9
+    Carbon:
+      amount: 1
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetPlasteel1
+
+- type: reaction
+  id: SolidifyBrass
+  impact: Low
+  quantized: true
+  reactants:
+    Zinc:
+      amount: 3.3
+    Copper:
+      amount: 6.7
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetBrass1
+
+- type: reaction
+  id: SolidifyPlasma
+  impact: Low
+  quantized: true
+  reactants:
+    Plasma:
+      amount: 10
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetPlasma1
+
+- type: reaction
+  id: SolidifyUranium
+  impact: Low
+  quantized: true
+  reactants:
+    Uranium:
+      amount: 8
+    Radium:
+      amount: 2
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetUranium1
+
+- type: reaction
+  id: SolidifyGlass
+  impact: Low
+  quantized: true
+  reactants:
+    Silicon:
+      amount: 10
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetGlass1
+
+- type: reaction
+  id: SolidifyRGlass
+  impact: Low
+  quantized: true
+  priority: 1 # higher priority than SolidifyGlass and Kelotane
+  reactants:
+    Silicon:
+      amount: 10
+    Iron:
+      amount: 4.5
+    Carbon:
+      amount: 0.5
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetRGlass1
+
+- type: reaction
+  id: SolidifyPGlass
+  impact: Low
+  quantized: true
+  priority: 1 # higher priority than SolidifyGlass and SolidifyPlasma
+  reactants:
+    Silicon:
+      amount: 10
+    Plasma:
+      amount: 10
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetPGlass1
+
+- type: reaction
+  id: SolidifyRPGlass
+  impact: Low
+  quantized: true
+  priority: 2 # higher priority than SolidifyRGlass and SolidifyPGlass
+  reactants:
+    Silicon:
+      amount: 10
+    Plasma:
+      amount: 10
+    Iron:
+      amount: 4.5
+    Carbon:
+      amount: 0.5
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetRPGlass1
+
+- type: reaction
+  id: SolidifyUGlass
+  impact: Low
+  quantized: true
+  priority: 1 # higher priority than SolidifyGlass and SolidifyUranium
+  reactants:
+    Silicon:
+      amount: 10
+    Uranium:
+      amount: 8
+    Radium:
+      amount: 2
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetUGlass1
+
+- type: reaction
+  id: SolidifyRUGlass
+  impact: Low
+  quantized: true
+  priority: 2 # higher priority than SolidifyRGlass and SolidifyUGlass
+  reactants:
+    Silicon:
+      amount: 10
+    Uranium:
+      amount: 8
+    Radium:
+      amount: 2
+    Iron:
+      amount: 4.5
+    Carbon:
+      amount: 0.5
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetRUGlass1
+
+- type: reaction
+  id: SolidifyClockworkGlass
+  impact: Low
+  quantized: true
+  priority: 1 # higher priority than SolidifyGlass and SolidifyBrass
+  reactants:
+    Silicon:
+      amount: 10
+    Zinc:
+      amount: 3.3
+    Copper:
+      amount: 6.7
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: SheetClockworkGlass1
+
+- type: reaction
+  id: SolidifyGold
+  impact: Low
+  quantized: true
+  reactants:
+    Gold:
+      amount: 10
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: IngotGold1
+
+- type: reaction
+  id: SolidifySilver
+  impact: Low
+  quantized: true
+  reactants:
+    Silver:
+      amount: 10
+    Fresium:
+      amount: 5
+  effects:
+  - !type:SpawnEntity
+    entity: IngotSilver1


### PR DESCRIPTION
## What was changed
Inspired by https://github.com/michaelchessall/SS14-Persistence/pull/211

Allows chemGODS and atmosGODS/botanyGODS to team up and mass produce mats. Everything can be solidified with 5u fresium. The existing gold and silver solidification reactions have been changed to use fresium instead of frost oil as well.

These are the mats that can be solidified:
<img width="290" height="213" alt="2026-06-27_02-12-16" src="https://github.com/user-attachments/assets/cc1e234c-b5cd-49c4-8dad-136811b521ce" />

Fresium can now also be obtained by centrifuging frost oil:
<img width="653" height="161" alt="2026-06-27_03-44-31" src="https://github.com/user-attachments/assets/371f02fb-e0e7-48f0-94ad-6cf79ab046cc" />

Also, changed uranium glass to contain 8 uranium and 2 radium instead of 10 uranium, for consistency with uranium sheets.

## Why

Total chem victory

## Media

## Requirements
- [X] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] Design doc

## Breaking changes
<!-- List any changes that might break future work -->

**Changelog**
:cl:
- add: Various materials like steel and glass can now be solidified from their liquid counterparts with 5u fresium
- add: Fresium can now be obtained by centrifuging frost oil
