### PR TITLE
ESSENTIALLY revert #36336

### DIFF
--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -67,6 +67,18 @@ public sealed partial class StaminaComponent : Component
     public ProtoId<AlertPrototype> StaminaAlert = "Stamina";
 
     /// <summary>
+    /// This flag indicates whether the value of <see cref="StaminaDamage"/> decreases after the entity exits stamina crit.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool AfterCritical;
+
+    /// <summary>
+    /// This float determines how fast stamina will regenerate after exiting the stamina crit.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float AfterCritDecayMultiplier = 5f;
+
+    /// <summary>
     /// This is how much stamina damage a mob takes when it forces itself to stand up before modifiers
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -67,18 +67,6 @@ public sealed partial class StaminaComponent : Component
     public ProtoId<AlertPrototype> StaminaAlert = "Stamina";
 
     /// <summary>
-    /// This flag indicates whether the value of <see cref="StaminaDamage"/> decreases after the entity exits stamina crit.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool AfterCritical;
-
-    /// <summary>
-    /// This float determines how fast stamina will regenerate after exiting the stamina crit.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public float AfterCritDecayMultiplier = 5f;
-
-    /// <summary>
     /// This is how much stamina damage a mob takes when it forces itself to stand up before modifiers
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -450,6 +450,7 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         }
 
         component.Critical = false;
+        component.StaminaDamage = 0; // KS14 change
         component.AfterCritical = true;  // Set to true to indicate that stamina will be restored after exiting stamcrit
         component.NextUpdate = Timing.CurTime;
 

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -336,14 +336,12 @@ public abstract partial class SharedStaminaSystem : EntitySystem
 
         UpdateStaminaVisuals((uid, component));
 
-        // KS14 change start
         // Checking if the stamina damage has decreased to zero after exiting the stamcrit
-        if (oldDamage > component.StaminaDamage && component.StaminaDamage <= 0f)
+        if (component.AfterCritical && oldDamage > component.StaminaDamage && component.StaminaDamage <= 0f)
         {
+            component.AfterCritical = false; // Since the recovery from the crit has been completed, we are no longer 'after crit'
             _status.TryRemoveStatusEffect(uid, StaminaLow);
         }
-
-        // KS14 change end
 
         if (!component.Critical)
         {
@@ -408,20 +406,16 @@ public abstract partial class SharedStaminaSystem : EntitySystem
             if (nextUpdate > curTime)
                 continue;
 
-            // Handle exiting critical condition and restoring stamina damage KS14: instantly
+            // Handle exiting critical condition and restoring stamina damage
             if (comp.Critical)
                 ExitStamCrit(uid, comp);
 
             comp.NextUpdate += TimeSpan.FromSeconds(1f);
 
-            //KS14 change start
-
             TakeStaminaDamage(
                 uid,
-                -comp.Decay,
+                comp.AfterCritical ? -comp.Decay * comp.AfterCritDecayMultiplier : -comp.Decay, // Recover faster after crit
                 comp);
-
-            //KS14 change end
 
             Dirty(uid, comp);
         }
@@ -456,10 +450,7 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         }
 
         component.Critical = false;
-        //KS14 change start
-        component.StaminaDamage = 0f;
-        // component.AfterCritical = true;  // Set to true to indicate that stamina will be restored after exiting stamcrit
-        //KS14 change end
+        component.AfterCritical = true;  // Set to true to indicate that stamina will be restored after exiting stamcrit
         component.NextUpdate = Timing.CurTime;
 
         UpdateStaminaVisuals((uid, component));

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -336,12 +336,14 @@ public abstract partial class SharedStaminaSystem : EntitySystem
 
         UpdateStaminaVisuals((uid, component));
 
+        // KS14 change start
         // Checking if the stamina damage has decreased to zero after exiting the stamcrit
-        if (component.AfterCritical && oldDamage > component.StaminaDamage && component.StaminaDamage <= 0f)
+        if (oldDamage > component.StaminaDamage && component.StaminaDamage <= 0f)
         {
-            component.AfterCritical = false; // Since the recovery from the crit has been completed, we are no longer 'after crit'
             _status.TryRemoveStatusEffect(uid, StaminaLow);
         }
+
+        // KS14 change end
 
         if (!component.Critical)
         {
@@ -406,16 +408,20 @@ public abstract partial class SharedStaminaSystem : EntitySystem
             if (nextUpdate > curTime)
                 continue;
 
-            // Handle exiting critical condition and restoring stamina damage
+            // Handle exiting critical condition and restoring stamina damage KS14: instantly
             if (comp.Critical)
                 ExitStamCrit(uid, comp);
 
             comp.NextUpdate += TimeSpan.FromSeconds(1f);
 
+            //KS14 change start
+
             TakeStaminaDamage(
                 uid,
-                comp.AfterCritical ? -comp.Decay * comp.AfterCritDecayMultiplier : -comp.Decay, // Recover faster after crit
+                -comp.Decay,
                 comp);
+
+            //KS14 change end
 
             Dirty(uid, comp);
         }
@@ -450,7 +456,10 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         }
 
         component.Critical = false;
-        component.AfterCritical = true;  // Set to true to indicate that stamina will be restored after exiting stamcrit
+        //KS14 change start
+        component.StaminaDamage = 0f;
+        // component.AfterCritical = true;  // Set to true to indicate that stamina will be restored after exiting stamcrit
+        //KS14 change end
         component.NextUpdate = Timing.CurTime;
 
         UpdateStaminaVisuals((uid, component));


### PR DESCRIPTION
## What was changed
<!-- If changelog sufficiently describes your changes, you may omit this section -->
Stamina damage now recovers instantly after fullstun. There is 3s grace period before full recovery.
## Why
stamina damage is aids already
## Media

## Requirements
- [x] Tested, works.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [no] Design doc

## Breaking changes
<!-- List any changes that might break future work -->

**Changelog**
:cl: d
- tweak: Stamina damage now recovers instantly after fullstun (again)!
