### PR TITLE
scenario QOL, ivpump fix, ammo balance tweak, lamp heal

### DIFF
--- a/Content.Client/Implants/UI/ChameleonControllerMenu.xaml.cs
+++ b/Content.Client/Implants/UI/ChameleonControllerMenu.xaml.cs
@@ -71,7 +71,17 @@ public sealed partial class ChameleonControllerMenu : FancyWindow
 
             var outfitButton = CreateOutfitButton(disabled, name, jobIconProto, outfit.ID);
 
-            if (outfit.Job != null && _job.TryGetLowestWeightDepartment(outfit.Job, out var departmentPrototype))
+            // KS14: check for departments too, kinda shitcoded but this is to accomodate for scenario chameleon protos being able to fall under a dept.
+            // KS14 Start
+            // fallback to first and only department in Departments if job isnt available
+            Shared.Roles.DepartmentPrototype? departmentPrototype = null;
+            if ((outfit.Job is not { } ||
+                !_job.TryGetLowestWeightDepartment(outfit.Job, out departmentPrototype)) &&
+                outfit.Departments?.Count == 1)
+                _prototypeManager.TryIndex(outfit.Departments![0], out departmentPrototype);
+            // KS14 End
+
+            if (departmentPrototype is { })
             {
                 if (!departments.ContainsKey(departmentPrototype.Name))
                     departments.Add(departmentPrototype.Name, CreateDepartment(departmentPrototype.Name));

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedGunSystem
         // Continuous loading
         _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.FillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid)
         {
-            BreakOnMove = true,
+            BreakOnMove = false /* KS14: don't break ammo fill on move */,
             BreakOnDamage = false,
             NeedHand = true,
         });

--- a/Resources/Locale/en-US/_KS14/chameleon-outfits/chameleon-outfits.ftl
+++ b/Resources/Locale/en-US/_KS14/chameleon-outfits/chameleon-outfits.ftl
@@ -1,0 +1,1 @@
+chameleon-outfit-scenario-nanoplant-nt-name = Nanoplant

--- a/Resources/Maps/_KS14/Scenarios/Nanoplant/raidbase.yml
+++ b/Resources/Maps/_KS14/Scenarios/Nanoplant/raidbase.yml
@@ -4233,7 +4233,7 @@ entities:
     - type: Transform
       pos: 19.53119,-13.603879
       parent: 1
-- proto: ColMarTechScenarioTiderfallSyndie
+- proto: ColMarTechScenarioNanoplantSyndie
   entities:
   - uid: 1036
     components:

--- a/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
@@ -246,6 +246,23 @@
     entries:
       CottonBurger: NukiePlushie
 
+- type: entity
+  parent: BasePlushie
+  id: PlushieLamp
+  name: lamp plushie
+  description: A light emitting friend!
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/Plushies/lamp.rsi
+    state: icon
+  - type: PointLight
+    radius: 1.5
+    energy: 2
+    netsync: false
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: LampPlushie
+
 # KS14 - Removed plushies
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -15,12 +15,12 @@
   - type: RemoveCompOnCollide
     taggedComponents:
       HristovWindowVentable:
-        - type: Airtight
-        - type: DeltaPressure
+      - type: Airtight
+      - type: DeltaPressure
   - type: AddCompOnCollide
     taggedComponents:
       HristovWindowVentable:
-        - type: HristovAppearance
+      - type: HristovAppearance
   - type: StaminaDamageOnCollide
     damage: 60
 
@@ -45,9 +45,9 @@
   - type: RemoveCompOnCollide
     taggedComponents:
       HristovWindowVentable:
-        - type: Airtight
-        - type: DeltaPressure
+      - type: Airtight
+      - type: DeltaPressure
   - type: AddCompOnCollide
     taggedComponents:
       HristovWindowVentable:
-        - type: HristovAppearance
+      - type: HristovAppearance

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_assembly.yml
@@ -46,5 +46,10 @@
   - type: Construction
     graph: Airlock
     node: assembly
+  # KS14 Start: let this be penned by hristov
+  - type: Tag
+    tags:
+    - HristovWindowVentable
+  # KS14 End
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -190,6 +190,7 @@
       # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, and HighSecDoor
       - DoorRemoteWhitelist
       # This tag is used by door remotes to allow or not a door remote to normally be able to interact with a door
+      - HristovWindowVentable # KS14: let this be penned by hristov
   - type: PryUnpowered
   - type: BlockWeather
   - type: GuideHelp
@@ -251,3 +252,4 @@
       # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, and HighSecDoor
       - DoorRemoteWhitelist
       # This tag is used by door remotes to allow or not a door remote to normally be able to interact with a door
+      - HristovWindowVentable # KS14: let this be penned by hristov

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -79,6 +79,7 @@
   - type: Tag
     tags:
       - ForceNoFixRotations
+      - HristovWindowVentable # KS14: let this be penned by hristov
   - type: Construction
     graph: AirlockShuttle
     node: airlock

--- a/Resources/Prototypes/_KS14/Entities/Structures/Piping/Plumbing/ivpump.yml
+++ b/Resources/Prototypes/_KS14/Entities/Structures/Piping/Plumbing/ivpump.yml
@@ -2,14 +2,11 @@
 - type: entity
   parent: PlumbingMachineBase
   id: KsPlumbingIvPump
-  name: plumbing iv pump
+  name: plumbing intravenous pump
   description: Used for streamlining the process of medicine.
   components:
   - type: Physics
     bodyType: Static
-    canCollide: false
-  - type: Fixtures
-    fixtures: {}
 
   - type: Sprite
     sprite: _KS14/Structures/Piping/Plumbing/iv_pump.rsi

--- a/Resources/Prototypes/_KS14/Roles/Jobs/Scenario/chameleon.yml
+++ b/Resources/Prototypes/_KS14/Roles/Jobs/Scenario/chameleon.yml
@@ -1,0 +1,22 @@
+
+
+- type: chameleonOutfit
+  id: ScenarioNanoplantNtChameleon
+  loadoutName: chameleon-outfit-scenario-nanoplant-nt-name
+  name: job-description-scenario-nt
+  icon: "JobIconNanotrasen"
+  departments:
+  - Scenario
+  hasMindShield: true
+  equipment:
+    head: ClothingHeadHelmetERTSecurity
+    eyes: ClothingEyesGlassesCommand
+    ears: ClothingHeadsetSecurity
+    mask: ClothingMaskGasSecurity
+    outerClothing: ClothingOuterArmorBasic
+    jumpsuit: ClothingUniformJumpsuitERTSecurity
+    belt: ClothingBeltMilitaryWebbingERT
+    back: ClothingBackpackERTSecurity
+    gloves: ClothingHandsGlovesCombat
+    shoes: ClothingShoesBootsLaceup
+    id: NanoplantNtPDA

--- a/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendors.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendors.yml
@@ -19,7 +19,6 @@
         - IDCARD
         - FEET
         - GLOVES
-        - BELT
       - id: ScenarioVendorBundleNanoplantNtEngineer
         replaceSlot: *replaceSlots
       - id: ScenarioVendorBundleNanoplantNtMarksman
@@ -30,3 +29,42 @@
         replaceSlot: *replaceSlots
       - id : ScenarioVendorBundleNanoplantNtCounterAssault
         replaceSlot: *replaceSlots
+
+- type: entity
+  parent: ColMarTechScenarioBase
+  id: ColMarTechScenarioNanoplantSyndie
+  suffix: Nanoplant, Syndicate
+  components:
+  - type: Sprite
+    sprite: _Crescent/Structures/syndicatearmory.rsi
+  - type: CMAutomatedVendor
+    sections:
+    - name: Base Gear
+      choices: { BaseGear: 1 }
+      entries:
+      - id: ScenarioVendorBundleNanoplantSyndieBase
+        recommended: true
+    - name: Loadout
+      choices: { CMClass: 1 }
+      entries:
+      - id: ScenarioVendorBundleNanoplantSyndieSoldier
+        recommended: true
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieInfiltrator
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieDemolitionist
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieSniper
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieMedic
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieMelee
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieEngineer
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieDroneOperator
+        replaceSlot: *replaceSlots
+    - name: Utilities
+      entries:
+      - id: EmpGrenade
+        amount: 2

--- a/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendors.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendors.yml
@@ -48,7 +48,10 @@
     - name: Loadout
       choices: { CMClass: 1 }
       entries:
-      - id: ScenarioVendorBundleNanoplantSyndieSoldier
+      - id: ScenarioVendorBundleNanoplantSyndieSoldierHushpup
+        recommended: true
+        replaceSlot: *replaceSlots
+      - id: ScenarioVendorBundleNanoplantSyndieSoldierC20r
         recommended: true
         replaceSlot: *replaceSlots
       - id: ScenarioVendorBundleNanoplantSyndieInfiltrator

--- a/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendors.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendors.yml
@@ -19,6 +19,7 @@
         - IDCARD
         - FEET
         - GLOVES
+        - BELT
       - id: ScenarioVendorBundleNanoplantNtEngineer
         replaceSlot: *replaceSlots
       - id: ScenarioVendorBundleNanoplantNtMarksman

--- a/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
@@ -15,16 +15,16 @@
     - ClothingBackpackERTSecurity
     - ClothingShoesBootsLaceup
     - ClothingMaskGasSecurity
-    - NanoplantNtPDA
     - ClothingHeadsetSecurity
     - ClothingEyesGlassesCommand
     - ClothingOuterArmorBasic
     - ClothingHeadHelmetERTSecurity
     - ClothingBeltMilitaryWebbingERT
+    - NanoplantNtPDA # intentionally after webbing so it doesnt go on belt
     - ClothingHandsGlovesCombat
     - Machete
-    - FlashlightSeclite
     - Gauze
+    - FlashlightSeclite
 
 - type: entity
   id: ScenarioVendorBundleNanoplantNtRifleman
@@ -120,12 +120,8 @@
     state: base
   - type: CMVendorBundle
     bundle:
-    - ClothingBeltUtilityEngineering
     - ClothingHeadHatHardhatYellow
     - RemoteSignallerAdvanced
-    - RemoteDroneLaptop
-    - RemoteDroneFpv
-    - RemoteDroneFpv
     - WeaponPistolMk58
     - MagazinePistol
     - MagazinePistol
@@ -135,6 +131,10 @@
     - CableApcStack10
     - ExplosivePayload
     - ExplosivePayload
+    - ClothingBeltUtilityEngineering
+    - RemoteDroneLaptop
+    - RemoteDroneFpv
+    - RemoteDroneFpv
 
 - type: entity
   id: ScenarioVendorBundleNanoplantNtMedic
@@ -175,9 +175,9 @@
     - ClothingBackpackSyndicate
     - ClothingShoesBootsCombat
     - ClothingMaskGasSyndicate
-    - TiderfallSyndiePDA
     - ClothingHeadsetAltSyndicate
     - ClothingBeltMilitaryWebbing
+    - TiderfallSyndiePDA # intentionally after webbing so it doesnt go on belt
     - ClothingEyesHudSyndicate # it's about time
     - ClothingHandsGlovesCombat
     - FlashlightSeclite
@@ -325,13 +325,8 @@
     state: base
   - type: CMVendorBundle
     bundle:
-    - ClothingBeltUtilityEngineering
     - ClothingHeadHatHardhatRed
     - RemoteSignallerAdvanced
-    - RemoteDroneLaptop
-    - RemoteDroneFpv
-    - RemoteDroneFpv
-    - RemoteDroneFpv
     - WeaponPistolCobra
     - MagazinePistolCaselessRifle
     - MagazinePistolCaselessRifle
@@ -343,3 +338,8 @@
     - ExplosivePayload
     - ExplosivePayload
     - ExplosivePayload
+    - ClothingBeltUtilityEngineering
+    - RemoteDroneLaptop
+    - RemoteDroneFpv
+    - RemoteDroneFpv
+    - RemoteDroneFpv

--- a/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
@@ -21,8 +21,10 @@
     - ClothingOuterArmorBasic
     - ClothingHeadHelmetERTSecurity
     - ClothingBeltMilitaryWebbingERT
+    - ClothingHandsGlovesCombat
     - Machete
-    - BoxFlare
+    - FlashlightSeclite
+    - Gauze
 
 - type: entity
   id: ScenarioVendorBundleNanoplantNtRifleman
@@ -31,7 +33,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
-    sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
+    sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
     state: icon
   - type: CMVendorBundle
     bundle:
@@ -154,3 +156,190 @@
     - PowerCellHigh
     - WeaponRifleLecter
     - MagazineRifle
+
+
+### SYNDIE
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieBase
+  name: base clothes
+  description: Welcome aboard listening post Mike-458, operative.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Clothing/Mask/gassyndicate.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - ClothingUniformJumpsuitOperative
+    - ClothingBackpackSyndicate
+    - ClothingShoesBootsCombat
+    - ClothingMaskGasSyndicate
+    - TiderfallSyndiePDA
+    - ClothingHeadsetAltSyndicate
+    - ClothingBeltMilitaryWebbing
+    - ClothingEyesHudSyndicate # it's about time
+    - ClothingHandsGlovesCombat
+    - FlashlightSeclite
+    - Gauze
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieSoldier
+  name: combat operative
+  description: Third-rate gear. Will have to do.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Shotguns/hushpup.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - WeaponShotgunHushpup
+    - BoxLethalshot
+    - ClothingHeadHelmetSwatSyndicate
+    - ClothingOuterArmorBasic
+    - Machete
+    - GrenadeStinger
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieInfiltrator
+  name: infiltrator
+  description: Pretend to be with them. Until you aren't.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Pistols/cobra.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-0
+      map: ["enum.GunVisualLayers.Mag"]
+  - type: CMVendorBundle
+    bundle:
+    - ClothingBackpackChameleonFillAgent # ..Agent comes with an ID card
+    - WeaponPistolCobra
+    - MagazinePistolCaselessRifle
+    - MagazinePistolCaselessRifle
+    - MagazinePistolCaselessRifle
+    - AccessBreaker
+    - SyndicateJawsOfLife
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieDemolitionist
+  name: demolitionist
+  description: Don't blow yourself up.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Chapel/quran.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - WeaponPistolViper
+    - MagazinePistol
+    - C4
+    - C4
+    - C4
+    - BibleQuran
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieSniper
+  name: sniper
+  description: 360 swagscope these fools.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
+    state: base
+  - type: CMVendorBundle
+    bundle:
+    - WeaponSniperHristov
+    - MagazineBoxAntiMateriel
+    - MagazineBoxAntiMateriel
+    - SmokeGrenade
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieMedic
+  name: medic
+  description: CLEAR!
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Hud/med.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - MedTekCartridge
+    - ClothingEyesHudSyndicateAgent
+    - ClothingBeltMedicalFilled
+    - MedkitCombatFilled
+    - AdvancedJetInjector
+    - DefibrillatorSyndicate
+    - PowerCellHigh
+    - Stimpack
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieMelee
+  name: liquidator
+  description: Commander Roland smiles upon you.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: /Textures/Objects/Weapons/Melee/e_sword.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - EnergySword
+    - ClothingShoesChameleonNoSlips
+    - ClothingOuterArmorRiot
+    - ClothingHeadHelmetRiot
+    - StimpackMini
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieEngineer
+  name: combat technician
+  description: Area lockdown initiated.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Toolboxes/toolbox_syn.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - ToolboxSyndicateTurret
+    - ClothingBeltUtilityEngineering
+    - WelderIndustrial
+    - SheetSteel
+    - SheetRGlass
+    - MaterialWoodPlank
+    - ClothingHeadHatHardhatRed
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieDroneOperator
+  name: drone operator
+  description: Remote fragging work.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: _KS14/Objects/Misc/fpv_drone.rsi
+    state: base
+  - type: CMVendorBundle
+    bundle:
+    - ClothingBeltUtilityEngineering
+    - ClothingHeadHatHardhatRed
+    - RemoteSignallerAdvanced
+    - RemoteDroneLaptop
+    - RemoteDroneFpv
+    - RemoteDroneFpv
+    - RemoteDroneFpv
+    - WeaponPistolCobra
+    - MagazinePistolCaselessRifle
+    - MagazinePistolCaselessRifle
+    - SignalTrigger
+    - SignalTrigger
+    - SignalTrigger
+    - SheetSteel
+    - CableApcStack10
+    - ExplosivePayload
+    - ExplosivePayload
+    - ExplosivePayload

--- a/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
@@ -188,9 +188,9 @@
     - Gauze
 
 - type: entity
-  id: ScenarioVendorBundleNanoplantSyndieSoldier
-  name: combat operative
-  description: Third-rate gear. Will have to do.
+  id: ScenarioVendorBundleNanoplantSyndieSoldierHushpup
+  name: combat operative (hushpup)
+  description: Third-rate gear. Will have to do. Comes with a hushpup and a box of buckshot.
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
@@ -200,6 +200,25 @@
     bundle:
     - WeaponShotgunHushpup
     - BoxLethalshot
+    - ClothingHeadHelmetSwatSyndicate
+    - ClothingOuterArmorBasic
+    - Machete
+    - GrenadeStinger
+
+- type: entity
+  id: ScenarioVendorBundleNanoplantSyndieSoldierC20r
+  name: combat operative (c-20r)
+  description: Third-rate gear. Will have to do. Comes with a C-20r and two mags.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - WeaponSubMachineGunC20r
+    - MagazinePistolSubMachineGun
+    - MagazinePistolSubMachineGun
     - ClothingHeadHelmetSwatSyndicate
     - ClothingOuterArmorBasic
     - Machete

--- a/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Nanoplant/vendprotos.yml
@@ -1,3 +1,7 @@
+
+# Be mindful of the order which things in the bundle are ordered
+# Things later in the list will override earlier things
+
 # Nanotrasen
 
 - type: entity

--- a/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendors.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendors.yml
@@ -21,7 +21,6 @@
         - IDCARD
         - FEET
         - GLOVES
-        - BELT
       - id: ScenarioVendorBundleTiderfallNtTider
         replaceSlot: *replaceSlots
       - id: ScenarioVendorBundleTiderfallNtClown

--- a/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendors.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendors.yml
@@ -21,6 +21,7 @@
         - IDCARD
         - FEET
         - GLOVES
+        - BELT
       - id: ScenarioVendorBundleTiderfallNtTider
         replaceSlot: *replaceSlots
       - id: ScenarioVendorBundleTiderfallNtClown

--- a/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendprotos.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendprotos.yml
@@ -190,9 +190,9 @@
     - ClothingBackpackSyndicate
     - ClothingShoesBootsCombat
     - ClothingMaskGasSyndicate
-    - TiderfallSyndiePDA
     - ClothingHeadsetAltSyndicate
     - ClothingBeltMilitaryWebbing
+    - TiderfallSyndiePDA # intentionally after webbing so it doesnt go on belt
     - ClothingEyesGlassesCommand # it's about time
     - BoxFlare
 

--- a/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendprotos.yml
+++ b/Resources/Prototypes/_KS14/scenarios/Tiderfall/vendprotos.yml
@@ -1,3 +1,7 @@
+
+# Be mindful of the order which things in the bundle are ordered
+# Things later in the list will override earlier things
+
 # Nanotrasen
 
 - type: entity

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
@@ -91,6 +91,7 @@
     isRPLD: true
     availablePrototypes:
     - KsPlumbingTeleporterBeacon # KS14: plumbing teleporters
+    - KsPlumbingIvPump # KS14
     - PlumbingRpldDuctStraight
     - PlumbingRpldDuctBend
     - PlumbingRpldDuctTJunction

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
@@ -1,7 +1,7 @@
 # Base plumbing machine entity - all plumbing machines inherit from this
 - type: entity
-  abstract: true
   id: PlumbingMachineBase
+  abstract: true
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/migration_ks14.yml
+++ b/Resources/migration_ks14.yml
@@ -10,7 +10,6 @@ PlushieRGBee: null
 PlushieSlime: null
 PlushieSnake: null
 PlushieExperiment: null
-PlushieLamp: null # TODO KS14: is this really needed
 PlushieLizard: null
 PlushieLizardMirrored: null # DIfferent from below
 PlushieLizardInversed: null # Different from above


### PR DESCRIPTION
## What was changed
re-added lamp plushies
fixed collisions for iv pump
added ivpump to rped
see cl basically
made hristov pen airlocks and assemblies

**Changelog**
:cl:
- add: Added a chameleon preset for the base outfit of Nanoplant's NT personnel.
- add: Added combat gloves to the loadouts of both sides on Nanoplant.
- add: Added a C-20r class to Nanoplant syndie vendor, alongside the hushpup.
- tweak: The doafter for refilling things with ammo is no longer broken when moving about.
- fix: Fixed base outfit for Nanoplant NT and Syndie being weird (PDA on belt slot, etc.).
- fix: Fixed collisions on IV pump, and fixed it not being in RPED when it was supposed to be.
- tweak: Hristov now penetrates airlocks (other than high-sec) and airlock assemblies.