### PR TITLE
feat(ks14): add IRST life-sign blips and fix sensor console performance

### DIFF
--- a/.github/workflows/build-test-debug-nosecret.yml
+++ b/.github/workflows/build-test-debug-nosecret.yml
@@ -19,7 +19,7 @@ concurrency: # KS14: a newer commit supersedes a running build on the same branc
 
 jobs:
   build:
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: github.actor != 'PJBot' && github.event.pull_request.draft == false && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       fail-fast: false # KS14: one red shard must not cancel its siblings
       matrix:
@@ -134,6 +134,7 @@ jobs:
           NUnit.MapWarningTo=Failed `
           NUnit.TestOutputXml= `
           NUnit.NumberOfTestWorkers=1 `
+          NUnit.AssemblySelectLimit=100000 `
           "NUnit.Where=${{ matrix.where }}"
 
     # KS14: Removed test result archival

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -126,6 +126,7 @@ jobs:
           NUnit.MapWarningTo=Failed `
           NUnit.TestOutputXml= `
           NUnit.NumberOfTestWorkers=1 `
+          NUnit.AssemblySelectLimit=100000 `
           "NUnit.Where=${{ matrix.where }}"
 
     # KS14: Removed test result archival

--- a/.github/workflows/server-announcement-pr.yml
+++ b/.github/workflows/server-announcement-pr.yml
@@ -1,21 +1,26 @@
 name: Server Announcement on PR status update
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, closed]
+
+permissions: {}
 
 jobs:
   notify-server:
     runs-on: ubuntu-latest
     steps:
     - name: Send PR notification
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       run: |
         PR_NUMBER="${{ github.event.pull_request.number }}"
 
         # Build and send JSON
         JSON_PAYLOAD=$null
         PREFIX="(Space-Klovns/Klovnstation14) PR #${PR_NUMBER}"
-        SUFFIX="${{ github.event.pull_request.title }} by ${{ github.event.pull_request.user.login }}"
+        SUFFIX="$PR_TITLE by $PR_AUTHOR"
         MESSAGE="FUCK"
 
         if [[ "${{ github.event.action }}" == "closed" ]]; then

--- a/.github/workflows/yaml-linter-nosecret.yml
+++ b/.github/workflows/yaml-linter-nosecret.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
     name: YAML Linter
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: github.actor != 'PJBot' && github.event.pull_request.draft == false && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -168,7 +168,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
             var ourGridToView = ourGridToShuttle * shuttleToView;
             var color = _shuttles.GetIFFColor(ourGridId.Value, self: true);
 
-            KsDrawInterests(handle, ourGridToView, new Box2(mapPos.Position - MaxRadarRangeVector, mapPos.Position + MaxRadarRangeVector), (ourGridId.Value, ourGrid)); // KS14
+            KsDrawInterests(handle, ourGridToView, (ourGridId.Value, ourGrid)); // KS14
 
             // KS14: Moved fixture query to only encompass this
             if (fixturesQuery.HasComponent(ourGridId.Value))
@@ -300,15 +300,17 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
     }
 
     // KS14
-    private void KsDrawInterests(DrawingHandleScreen handle, Matrix3x2 curGridToViewMatrix, Box2 viewAABB, Entity<MapGridComponent> gridEntity)
+    private void KsDrawInterests(DrawingHandleScreen handle, Matrix3x2 curGridToViewMatrix, Entity<MapGridComponent> gridEntity)
     {
         foreach (var (_, interest) in _ksRadarInterestSystem.StaticInterests)
         {
             if (gridEntity.Owner != interest.Item2)
                 continue;
 
+            // Control pixels, so the cull box is the control: the old test compared
+            // pixels to a world-metres box.
             var interestPosition = Vector2.Transform(interest.Item3, curGridToViewMatrix);
-            if (!viewAABB.Contains(interestPosition))
+            if (!new UIBox2(Vector2.Zero, PixelSize).Contains(interestPosition))
                 continue;
 
             handle.DrawCircle(interestPosition, 5, Color.ToSrgb(Color.DarkGoldenrod), true);

--- a/Content.Client/_KS14/Shuttles/UI/KsEsmScreen.xaml.cs
+++ b/Content.Client/_KS14/Shuttles/UI/KsEsmScreen.xaml.cs
@@ -53,6 +53,13 @@ public sealed partial class KsEsmScreen : BoxContainer
     /// <summary>Postures by descending severity; the first met one shows.</summary>
     private readonly List<KsPosturePrototype> _postures;
 
+    // Session-constant strings, resolved once instead of per frame.
+    private readonly string _liveText = Loc.GetString("ks-elint-roster-live");
+    private readonly string _memoryText = Loc.GetString("ks-elint-roster-memory");
+    private readonly string _rwrNoValueText = Loc.GetString("ks-rwr-field-no-value");
+    private readonly string _elintNoValueText = Loc.GetString("ks-elint-field-no-value");
+    private readonly string _selectedNoneText = Loc.GetString("ks-elint-selected-none");
+
     private EntityUid? _shuttleEntity;
 
     private bool _hasElint;
@@ -65,8 +72,22 @@ public sealed partial class KsEsmScreen : BoxContainer
     /// </summary>
     private List<(KsSensorContactState Contact, KsThreatChannelPrototype? Channel)> _roster = new();
 
-    /// <summary>Roster rows, kept for the per-frame relative-bearing refresh and channel-rate blink.</summary>
-    private readonly List<(Button Row, KsSensorContactState Contact, KsThreatChannelPrototype? Channel)> _rosterRows = new();
+    /// <summary>
+    ///     Rows are remade every push, so chip/status resolve once at rebuild; between
+    ///         pushes only the bearing digits change and the frame pass skips
+    ///         unchanged rows entirely (a Text write invalidates layout).
+    /// </summary>
+    private readonly List<RosterRow> _rosterRows = new();
+
+    private sealed class RosterRow
+    {
+        public Button Button = default!;
+        public KsSensorContactState Contact = default!;
+        public KsThreatChannelPrototype? Channel;
+        public string Chip = string.Empty;
+        public string Status = string.Empty;
+        public string? LastDigits;
+    }
 
     /// <summary>Lit channel-counter rows, kept for the channel-rate blink.</summary>
     private readonly List<(Label Row, KsThreatChannelPrototype Channel)> _litChannelRows = new();
@@ -82,6 +103,12 @@ public sealed partial class KsEsmScreen : BoxContainer
     private readonly List<(int Index, KsSensorContactState Contact)> _plotFixes = new();
 
     private NetEntity? _selected;
+
+    /// <summary>Resolved on push/selection; FrameUpdate reads it every frame.</summary>
+    private KsSensorContactState? _selectedContact;
+
+    /// <summary>Push-constant, gates CEASE.</summary>
+    private bool _anyFocused;
 
     /// <summary>The posture the hosting window's ESM tab button should flash; null with no RWR receiver or nothing illuminating.</summary>
     public KsPosturePrototype? AlertPosture { get; private set; }
@@ -196,6 +223,9 @@ public sealed partial class KsEsmScreen : BoxContainer
         if (_selected != null && _roster.All(t => t.Contact.Grid != _selected))
             _selected = null;
 
+        _selectedContact = SelectedContact();
+        _anyFocused = _roster.Any(t => t.Contact.Focused);
+
         RwrChip.Visible = !_hasRwr;
         ChannelList.Visible = _hasRwr;
         PostureGrid.Visible = _hasRwr;
@@ -227,8 +257,9 @@ public sealed partial class KsEsmScreen : BoxContainer
     {
         _selected = grid;
         Plot.Selected = grid;
+        _selectedContact = SelectedContact();
         // A fresh selection starts its counter at the pushed value, no easing-in.
-        _analysisShown = SelectedContact()?.AnalysisProgress ?? 0f;
+        _analysisShown = _selectedContact?.AnalysisProgress ?? 0f;
         RebuildRoster();
         RefreshSelected();
     }
@@ -316,14 +347,27 @@ public sealed partial class KsEsmScreen : BoxContainer
             return;
         }
 
+        var own = OwnWorldPosition();
+        var rotation = OwnRotation();
+
         foreach (var (contact, channel) in _roster)
         {
+            var chip = channel != null
+                ? Loc.GetString(channel.Label)
+                : ClassLabel(contact);
+
+            // LIVE is the EMISSION, not the hull track: an ally's relay can keep the
+            // track alive after the emitter went silent. Dimming stays on track liveness.
+            var status = contact.EmitterLive ? _liveText : _memoryText;
+
+            var digits = RelativeBearingDigits(contact, own, rotation);
+
             var row = new Button
             {
                 StyleClasses = { KsInstrumentSheetlet.StyleClassAction },
                 HorizontalExpand = true,
                 Margin = new Thickness(0, 0, 0, 2),
-                Text = RosterRowText(contact, channel),
+                Text = RosterRowText(contact, chip, digits, status),
             };
             KsInstrumentSheetlet.MakeInstrument(row);
 
@@ -332,7 +376,15 @@ public sealed partial class KsEsmScreen : BoxContainer
             var grid = contact.Grid;
             row.OnPressed += _ => Select(grid);
             RosterList.AddChild(row);
-            _rosterRows.Add((row, contact, channel));
+            _rosterRows.Add(new RosterRow
+            {
+                Button = row,
+                Contact = contact,
+                Channel = channel,
+                Chip = chip,
+                Status = status,
+                LastDigits = digits,
+            });
         }
     }
 
@@ -341,27 +393,13 @@ public sealed partial class KsEsmScreen : BoxContainer
     ///         threat under an RWR fit, else the heard classification), the RELATIVE
     ///         bearing matching the BOW-up plot, and the LIVE/MEM emission status.
     /// </summary>
-    private string RosterRowText(KsSensorContactState contact, KsThreatChannelPrototype? channel)
+    private string RosterRowText(KsSensorContactState contact, string chip, string? digits, string status)
     {
-        return RosterRowText(contact, channel, OwnWorldPosition(), OwnRotation());
-    }
+        var bearing = digits != null
+            ? Loc.GetString("ks-rwr-threat-bearing", ("deg", digits))
+            : _rwrNoValueText;
 
-    private string RosterRowText(KsSensorContactState contact, KsThreatChannelPrototype? channel, Vector2? own, Angle rotation)
-    {
-        var chip = channel != null
-            ? Loc.GetString(channel.Label)
-            : ClassLabel(contact);
-
-        // LIVE means the EMISSION, not the hull track: an ally's relay can keep the
-        // track alive long after the emitter went silent, and a row claiming LIVE
-        // while the log says silent reads as a haunted receiver. The chip, log,
-        // threat stack and posture all key on EmitterLive already; row dimming
-        // stays on track liveness.
-        var status = contact.EmitterLive
-            ? Loc.GetString("ks-elint-roster-live")
-            : Loc.GetString("ks-elint-roster-memory");
-
-        return $"{contact.Designation,-6} {chip,-7} {RelativeBearingLabel(contact, own, rotation),4} {status,4}";
+        return $"{contact.Designation,-6} {chip,-7} {bearing,4} {status,4}";
     }
 
     /// <summary>
@@ -390,22 +428,11 @@ public sealed partial class KsEsmScreen : BoxContainer
     }
 
     /// <summary>
-    ///     The RELATIVE bearing shown on a roster row (000 = bow, matching the
-    ///         BOW-up plot): the strobe's direction for a bearing track, the
-    ///         direction toward the known position for a fix, a placeholder for a
-    ///         roster-only relay track.
+    ///     Relative bearing (000 = bow) as bare digits, null for a roster-only relay
+    ///         track: pure math, so the frame pass can compare before any Fluent
+    ///         lookup. Own position/rotation arrive pre-fetched, once per list.
     /// </summary>
-    private string RelativeBearingLabel(KsSensorContactState contact)
-    {
-        return RelativeBearingLabel(contact, OwnWorldPosition(), OwnRotation());
-    }
-
-    /// <summary>
-    ///     As <see cref="RelativeBearingLabel(KsSensorContactState)"/> with the own
-    ///         position/rotation pre-fetched: the per-frame roster refresh reads
-    ///         them once for the whole list instead of per row.
-    /// </summary>
-    private string RelativeBearingLabel(KsSensorContactState contact, Vector2? own, Angle rotation)
+    private string? RelativeBearingDigits(KsSensorContactState contact, Vector2? own, Angle rotation)
     {
         Angle? dir = null;
 
@@ -421,10 +448,9 @@ public sealed partial class KsEsmScreen : BoxContainer
         }
 
         if (dir is not { } d)
-            return Loc.GetString("ks-rwr-field-no-value");
+            return null;
 
-        var deg = KsBearingPlot.CompassDegrees(d - rotation);
-        return Loc.GetString("ks-rwr-threat-bearing", ("deg", $"{deg:000}"));
+        return $"{KsBearingPlot.CompassDegrees(d - rotation):000}";
     }
 
     /// <summary>
@@ -450,7 +476,7 @@ public sealed partial class KsEsmScreen : BoxContainer
 
         return deg is { } d
             ? Loc.GetString("ks-sensor-contact-bearing", ("deg", $"{d:000}"))
-            : Loc.GetString("ks-elint-field-no-value");
+            : _elintNoValueText;
     }
 
     private void RebuildChannels()
@@ -493,13 +519,13 @@ public sealed partial class KsEsmScreen : BoxContainer
 
         var posture = KsThreatEval.PickPosture(_postures, threatCount, litPriority);
 
-        PostureValue.Text = posture != null ? Loc.GetString(posture.Label) : Loc.GetString("ks-rwr-field-no-value");
+        PostureValue.Text = posture != null ? Loc.GetString(posture.Label) : _rwrNoValueText;
         PostureValue.FontColorOverride = posture?.Color ?? palette.TextDim;
 
         var priorityChannel = _litChannelRows.Count > 0
             ? _litChannelRows.MaxBy(r => r.Channel.Priority).Channel
             : null;
-        PriorityValue.Text = priorityChannel != null ? Loc.GetString(priorityChannel.Label) : Loc.GetString("ks-rwr-field-no-value");
+        PriorityValue.Text = priorityChannel != null ? Loc.GetString(priorityChannel.Label) : _rwrNoValueText;
         PriorityValue.FontColorOverride = priorityChannel?.Color ?? palette.TextDim;
 
         // The tab-alert only escalates: an unthreatened posture (the always-met
@@ -525,49 +551,53 @@ public sealed partial class KsEsmScreen : BoxContainer
         return Vector2.Transform(body.LocalCenter, worldMatrix);
     }
 
+    /// <summary>The Text setter invalidates layout even for identical text, and this runs per frame.</summary>
+    private static void SetText(Label label, string? text)
+    {
+        if (label.Text != text)
+            label.Text = text;
+    }
+
     private void RefreshSelected()
     {
         if (!_hasElint)
             return;
 
         var palette = Palette;
-        var contact = SelectedContact();
+        var contact = _selectedContact;
 
         FocusButton.Disabled = contact == null || contact.Focused;
-        CeaseButton.Disabled = _roster.All(t => !t.Contact.Focused);
+        CeaseButton.Disabled = !_anyFocused;
 
         if (contact == null)
         {
-            var none = Loc.GetString("ks-elint-selected-none");
-            DesigValue.Text = none;
-            ClassValue.Text = "";
-            BandValue.Text = "";
-            PatternValue.Text = "";
-            SignalValue.Text = "";
-            BearingValue.Text = "";
-            LastValue.Text = "";
-            AnalysisValue.Text = "";
+            SetText(DesigValue, _selectedNoneText);
+            SetText(ClassValue, "");
+            SetText(BandValue, "");
+            SetText(PatternValue, "");
+            SetText(SignalValue, "");
+            SetText(BearingValue, "");
+            SetText(LastValue, "");
+            SetText(AnalysisValue, "");
             DesigValue.FontColorOverride = palette.TextDim;
             return;
         }
 
-        var noValue = Loc.GetString("ks-elint-field-no-value");
-
-        DesigValue.Text = contact.Name != null ? $"{contact.Designation} {contact.Name}" : contact.Designation;
+        SetText(DesigValue, contact.Name != null ? $"{contact.Designation} {contact.Name}" : contact.Designation);
         DesigValue.FontColorOverride = contact.Live ? palette.Text : palette.TextDim;
-        ClassValue.Text = ClassLabel(contact);
-        BandValue.Text = contact.Band is { } band && _protoManager.TryIndex(band, out var bandProto)
+        SetText(ClassValue, ClassLabel(contact));
+        SetText(BandValue, contact.Band is { } band && _protoManager.TryIndex(band, out var bandProto)
             ? Loc.GetString(bandProto.Label)
-            : Loc.GetString("ks-emitter-band-unknown");
-        PatternValue.Text = contact.Pattern switch
+            : Loc.GetString("ks-emitter-band-unknown"));
+        SetText(PatternValue, contact.Pattern switch
         {
             KsEmissionPattern.Continuous => Loc.GetString("ks-emitter-pattern-continuous"),
             _ => Loc.GetString("ks-emitter-pattern-unknown"),
-        };
+        });
 
-        SignalValue.Text = contact.SignalStrength is { } signal
+        SetText(SignalValue, contact.SignalStrength is { } signal
             ? Loc.GetString("ks-elint-field-signal-value", ("percent", (int) MathF.Round(signal * 100f)))
-            : noValue;
+            : _elintNoValueText);
 
         // A fixed contact outranks any bearing-quality wording: closing in and
         // earning a position must read as the upgrade it is, not as STABLE
@@ -580,19 +610,19 @@ public sealed partial class KsEsmScreen : BoxContainer
                 KsBearingStability.Drifting => Loc.GetString("ks-sensor-stability-drifting"),
                 _ => Loc.GetString("ks-sensor-stability-unknown"),
             };
-        BearingValue.Text = Loc.GetString("ks-elint-field-bearing-value",
+        SetText(BearingValue, Loc.GetString("ks-elint-field-bearing-value",
             ("deg", CompassBearingLabel(contact)),
-            ("stability", stability));
+            ("stability", stability)));
 
         var age = (_timing.CurTime - contact.LastSeen).TotalSeconds;
-        LastValue.Text = age < 1.5
+        SetText(LastValue, age < 1.5
             ? Loc.GetString("ks-elint-field-last-seen-now")
-            : Loc.GetString("ks-elint-field-last-seen-value", ("seconds", (int) age));
+            : Loc.GetString("ks-elint-field-last-seen-value", ("seconds", (int) age)));
         LastValue.FontColorOverride = contact.Live ? palette.Good : palette.TextDim;
 
-        AnalysisValue.Text = contact.Focused
+        SetText(AnalysisValue, contact.Focused
             ? Loc.GetString("ks-elint-field-analysis-value", ("percent", (int) MathF.Round(_analysisShown * 100f)))
-            : Loc.GetString("ks-elint-field-analysis-idle");
+            : Loc.GetString("ks-elint-field-analysis-idle"));
         AnalysisValue.FontColorOverride = contact.Focused && contact.AnalysisProgress >= 1f ? palette.Good : palette.Text;
     }
 
@@ -618,24 +648,24 @@ public sealed partial class KsEsmScreen : BoxContainer
         var reduced = _cfg.GetCVar(KsCCVars.HudReducedMotion);
         var now = _timing.CurTime.TotalSeconds;
 
-        // Per-channel threat strobe on live threats (higher priority = faster),
-        // riding on top of the selection dim; the relative bearings re-read every
-        // frame so they turn with the hull like the plot does. The Text setter
-        // invalidates layout, so only a changed line is written back (the roster
-        // can hold every emitter ever designated, memory never expires).
+        // Threat strobe rides on the selection dim; bearings re-read per frame so
+        // rows turn with the hull.
         var rosterOwn = OwnWorldPosition();
         var rosterRotation = OwnRotation();
-        foreach (var (row, contact, channel) in _rosterRows)
+        foreach (var row in _rosterRows)
         {
-            var text = RosterRowText(contact, channel, rosterOwn, rosterRotation);
-            if (row.Text != text)
-                row.Text = text;
+            var digits = RelativeBearingDigits(row.Contact, rosterOwn, rosterRotation);
+            if (digits != row.LastDigits)
+            {
+                row.LastDigits = digits;
+                row.Button.Text = RosterRowText(row.Contact, row.Chip, digits, row.Status);
+            }
 
-            var tint = contact.Grid == _selected ? 1f : 0.75f;
-            var v = _hasRwr && contact.EmitterLive
-                ? Hud.ThreatStrobe.Eval(now, reduced, channel?.BlinkHz ?? 1f)
+            var tint = row.Contact.Grid == _selected ? 1f : 0.75f;
+            var v = _hasRwr && row.Contact.EmitterLive
+                ? Hud.ThreatStrobe.Eval(now, reduced, row.Channel?.BlinkHz ?? 1f)
                 : 1f;
-            row.Modulate = new Color(tint * v, tint * v, tint * v);
+            row.Button.Modulate = new Color(tint * v, tint * v, tint * v);
         }
 
         foreach (var (row, channel) in _litChannelRows)
@@ -654,8 +684,8 @@ public sealed partial class KsEsmScreen : BoxContainer
 
         // Ease the displayed ANALYSIS counter toward the pushed progress;
         // reduce-motion snaps it.
-        var target = SelectedContact()?.AnalysisProgress ?? 0f;
-        _analysisShown = _cfg.GetCVar(KsCCVars.HudReducedMotion)
+        var target = _selectedContact?.AnalysisProgress ?? 0f;
+        _analysisShown = reduced
             ? target
             : _analysisShown + (target - _analysisShown) * Math.Clamp(args.DeltaSeconds * 6f, 0f, 1f);
         if (MathF.Abs(target - _analysisShown) < 0.005f)

--- a/Content.Client/_KS14/Shuttles/UI/KsRadarControl.xaml.cs
+++ b/Content.Client/_KS14/Shuttles/UI/KsRadarControl.xaml.cs
@@ -90,12 +90,36 @@ public sealed partial class KsRadarControl : BaseShuttleControl
 
     private List<KsSensorContactState>? _ksContacts;
     private List<KsSensorRegionState>? _ksSensorRegions;
+    private List<KsLifeSignState>? _ksLifeSigns;
     private bool _ksJammed;
     private readonly HashSet<NetEntity> _ksLiveContacts = new();
     private readonly HashSet<NetEntity> _ksRealDrawn = new();
     private readonly List<(Vector2 ScreenPos, KsSensorContactState Contact)> _ksContactHits = new();
+
+    /// <summary>Draw scratch: this push's contacts by grid, for anchoring aboard life-sign dots.</summary>
+    private readonly Dictionary<NetEntity, KsSensorContactState> _ksContactsByGrid = new();
     private Vector2? _ksMousePos;
-    private List<KsSensorIntelPrototype>? _ksIntelRoster;
+    private List<(KsSensorIntelPrototype Proto, string Label)>? _ksIntelRoster;
+
+    /// <summary>Readout lines per contact, composed once per push: labels and values only change when a state lands, so composing in Draw was per-frame churn for identical text.</summary>
+    private readonly Dictionary<NetEntity, List<(KsContactDetail Detail, bool HasValue, string Text)>> _ksRosterLines = new();
+
+    /// <summary>
+    ///     Coords+range memo keyed on the printed integers (range also moves with own
+    ///         ship), so the Fluent format only runs when a digit ticks. Cleared per push.
+    /// </summary>
+    private readonly Dictionary<NetEntity, (string X, string Y, string R, string Text)> _ksPosRangeCache = new();
+
+    // Session-constant strings, resolved once instead of per frame.
+    private readonly string _ksUnknownText = Loc.GetString("ks-sensor-contact-unknown");
+    private readonly string _ksLiveText = Loc.GetString("ks-sensor-contact-live");
+    private readonly string _ksJammedText = Loc.GetString("ks-sensor-jammed");
+
+    /// <summary>Per-frame scratch for the coverage-fan vertices, sliced by BuildVerts' returned count.</summary>
+    private Vector2[] _ksRegionVerts = Array.Empty<Vector2>();
+
+    /// <summary>Per-frame scratch for the batched life-sign dot triangles, one chunk's worth.</summary>
+    private readonly Vector2[] _ksLifeSignVerts = new Vector2[KsLifeSignChunkVerts];
 
     /// <summary>Liveness edge detector driving the contact ping and the ghost fade.</summary>
     private readonly KsContactTransitions _ksTransitions = new();
@@ -215,8 +239,11 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         // sensor picture (no coverage) reads back as the old all-null/false defaults.
         _ksContacts = state.KsSensorNav?.Contacts;
         _ksSensorRegions = state.KsSensorNav?.Regions;
+        _ksLifeSigns = state.KsSensorNav?.LifeSigns;
         _ksJammed = state.KsSensorNav?.Jammed ?? false;
         _ksTransitions.Update(_ksContacts, _timing.CurTime);
+        KsRebuildRosterLines();
+        _ksPosRangeCache.Clear();
         _ksLiveContacts.Clear();
         if (_ksContacts != null)
         {
@@ -271,7 +298,7 @@ public sealed partial class KsRadarControl : BaseShuttleControl
             var ourGridToView = ourGridToShuttle * shuttleToView;
             var color = _shuttles.GetIFFColor(ourGridId.Value, self: true);
 
-            KsDrawInterests(handle, ourGridToView, new Box2(mapPos.Position - MaxRadarRangeVector, mapPos.Position + MaxRadarRangeVector), (ourGridId.Value, ourGrid));
+            KsDrawInterests(handle, ourGridToView, (ourGridId.Value, ourGrid));
 
             // Coverage fans, under the hull and contacts.
             KsDrawSensorRegions(handle, ourGridToView, worldToShuttle * shuttleToView, EntManager.GetNetEntity(ourGridId.Value));
@@ -347,6 +374,7 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         // Contact layer and hover tooltip on top of everything. mapPos.Position is the
         // radar's own centre in world space, used to label each contact's range.
         KsDrawContacts(handle, worldToShuttle * shuttleToView, mapPos.Position);
+        KsDrawLifeSigns(handle, worldToShuttle * shuttleToView);
         KsDrawContactTooltip(handle, mapPos.Position);
     }
 
@@ -374,10 +402,19 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         // instead of stepping on the sensor cadence.
         var estPos = contact.EstimatedPosition(curTime);
         var range = (estPos - ownWorldPos).Length();
-        return Loc.GetString("ks-sensor-contact-pos-range",
-            ("x", $"{estPos.X:0}"),
-            ("y", $"{estPos.Y:0}"),
-            ("range", $"{range:0}"));
+
+        var x = $"{estPos.X:0}";
+        var y = $"{estPos.Y:0}";
+        var r = $"{range:0}";
+        if (_ksPosRangeCache.TryGetValue(contact.Grid, out var cached)
+            && cached.X == x && cached.Y == y && cached.R == r)
+        {
+            return cached.Text;
+        }
+
+        var text = Loc.GetString("ks-sensor-contact-pos-range", ("x", x), ("y", y), ("range", r));
+        _ksPosRangeCache[contact.Grid] = (x, y, r, text);
+        return text;
     }
 
     /// <summary>
@@ -519,6 +556,92 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         }
     }
 
+    private const int KsDotSegments = 64;
+
+    /// <summary>Unit ring matching the engine DrawCircle tessellation exactly (64 segments, closed, fan pivots on a RIM vertex), so batched dots stay pixel-identical.</summary>
+    private static readonly Vector2[] KsDotRing = KsBuildDotRing();
+
+    /// <summary>
+    ///     10 whole dots (63 real triangles each) per draw call: the engine stackallocs
+    ///         per span vertex and its batch buffer caps near 64k, so one unbounded
+    ///         span could blow the render thread over a crowded station.
+    /// </summary>
+    private const int KsLifeSignChunkVerts = (KsDotSegments - 1) * 3 * 10;
+
+    private static Vector2[] KsBuildDotRing()
+    {
+        var ring = new Vector2[KsDotSegments + 1];
+        for (var i = 0; i <= KsDotSegments; i++)
+        {
+            var angle = i / (float) KsDotSegments * MathHelper.TwoPi;
+            ring[i] = new Vector2(MathF.Sin(angle), MathF.Cos(angle));
+        }
+
+        return ring;
+    }
+
+    /// <summary>
+    ///     One dot per live creature: aboard dots ride their contact's dead-reckoned
+    ///         hull, floaters sit at their swept world position. Off-view signs are
+    ///         culled outright - they are detail, not contacts, so nothing pins to
+    ///         the rim.
+    /// </summary>
+    private void KsDrawLifeSigns(DrawingHandleScreen handle, Matrix3x2 worldToView)
+    {
+        if (_ksLifeSigns == null || _ksLifeSigns.Count == 0)
+            return;
+
+        var curTime = _timing.CurTime;
+
+        _ksContactsByGrid.Clear();
+        if (_ksContacts != null)
+        {
+            foreach (var contact in _ksContacts)
+                _ksContactsByGrid[contact.Grid] = contact;
+        }
+
+        const float radius = 1.5f;
+        var count = 0;
+
+        foreach (var sign in _ksLifeSigns)
+        {
+            Vector2 worldPos;
+            if (sign.Grid is { } gridNet)
+            {
+                if (!_ksContactsByGrid.TryGetValue(gridNet, out var contact))
+                    continue;
+
+                worldPos = contact.EstimatedPosition(curTime) + contact.Rotation.RotateVec(sign.Position);
+            }
+            else
+            {
+                worldPos = sign.Position;
+            }
+
+            var pos = Vector2.Transform(worldPos, worldToView);
+            if (KsClampToRim(pos, out _))
+                continue;
+
+            var pivot = pos + KsDotRing[0] * radius;
+            for (var i = 1; i < KsDotRing.Length - 1; i++)
+            {
+                _ksLifeSignVerts[count++] = pivot;
+                _ksLifeSignVerts[count++] = pos + KsDotRing[i] * radius;
+                _ksLifeSignVerts[count++] = pos + KsDotRing[i + 1] * radius;
+            }
+
+            // Chunk is a whole number of dots, so a full buffer lands exactly here.
+            if (count == KsLifeSignChunkVerts)
+            {
+                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, _ksLifeSignVerts, KsHud.LifeSign);
+                count = 0;
+            }
+        }
+
+        if (count > 0)
+            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, _ksLifeSignVerts.AsSpan(0, count), KsHud.LifeSign);
+    }
+
     /// <summary>
     ///     The contact's colour this frame: the tier colour riding the phosphor afterglow
     ///         while live, or the memory-ghost tone, reached through a short fade when the
@@ -633,7 +756,7 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         if (!showName && !showCoords)
             return;
 
-        var name = showName ? contact.Name ?? Loc.GetString("ks-sensor-contact-unknown") : string.Empty;
+        var name = showName ? contact.Name ?? _ksUnknownText : string.Empty;
         var coords = showCoords ? KsContactPosRange(contact, ownWorldPos, curTime) : string.Empty;
 
         var nameDim = showName ? handle.GetDimensions(_ksFont, name, 0.7f) : Vector2.Zero;
@@ -779,7 +902,7 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         var lines = new List<(string Text, float Scale, float Alpha)>();
 
         if (KsReadoutDetail >= KsHud.NameDetail)
-            lines.Add((contact.Name ?? Loc.GetString("ks-sensor-contact-unknown"), 0.7f, 1f));
+            lines.Add((contact.Name ?? _ksUnknownText, 0.7f, 1f));
 
         // The bearing IS this contact's position line, so it answers to the same level.
         if (KsReadoutDetail >= KsHud.PositionDetail)
@@ -850,8 +973,7 @@ public sealed partial class KsRadarControl : BaseShuttleControl
     /// <summary>
     ///     Draws a contact's text readout as a left-aligned stack starting at
     ///         <paramref name="anchor"/> (the contact's upper-right corner): name,
-    ///         coordinates + range, memory age and the readout roster (every label, its
-    ///         value where a sensor resolved one, else a dimmed blank slot).
+    ///         coordinates + range, memory age and the readout roster.
     ///         <paramref name="intelOnly"/> draws only the roster, for a live contact
     ///         whose real hull is on screen.
     /// </summary>
@@ -863,7 +985,7 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         {
             if (KsReadoutDetail >= KsHud.NameDetail)
             {
-                handle.DrawString(_ksFont, line, contact.Name ?? Loc.GetString("ks-sensor-contact-unknown"), 0.7f, color);
+                handle.DrawString(_ksFont, line, contact.Name ?? _ksUnknownText, 0.7f, color);
                 line += new Vector2(0f, 11f);
             }
 
@@ -881,57 +1003,80 @@ public sealed partial class KsRadarControl : BaseShuttleControl
             }
         }
 
-        // The full roster, not only detected lines: the labels are a fixed panel, so a
-        // quantity no sensor of ours resolved reads as a dimmed blank slot rather than
-        // dropping its row and shifting the stack.
-        foreach (var intelProto in KsIntelRoster())
+        // The detail toggle is live between pushes, so its gate stays here.
+        if (!_ksRosterLines.TryGetValue(contact.Grid, out var roster))
+            return;
+
+        foreach (var (detail, hasValue, text) in roster)
         {
-            // Each readout declares the lowest detail level it survives at, so cutting
-            // the plot back is a YAML decision per quantity, not a hardcoded shortlist.
-            if (KsReadoutDetail < intelProto.Detail)
+            if (KsReadoutDetail < detail)
                 continue;
 
-            string? value = null;
-            foreach (var (intelId, v) in contact.Intel)
-            {
-                if (intelId.Id == intelProto.ID)
-                {
-                    value = v;
-                    break;
-                }
-            }
-
-            // A readout may opt out of the always-on roster; then it appears only when
-            // a value is actually present.
-            if (value == null && !intelProto.AlwaysShowLabel)
-                continue;
-
-            var shown = value ?? Loc.GetString("ks-sensor-intel-no-value");
-            // An unresolved value is dimmer, so the panel shows what is known apart
-            // from what is merely listed.
-            var alpha = value != null ? KsHud.ReadoutDetailAlpha : KsHud.ReadoutUnresolvedAlpha;
-            handle.DrawString(_ksFont, line, $"{Loc.GetString(intelProto.Label)}: {shown}", 0.6f, color.WithAlpha(alpha));
+            var alpha = hasValue ? KsHud.ReadoutDetailAlpha : KsHud.ReadoutUnresolvedAlpha;
+            handle.DrawString(_ksFont, line, text, 0.6f, color.WithAlpha(alpha));
             line += new Vector2(0f, 10f);
         }
     }
 
     /// <summary>
-    ///     The fixed roster of readout labels drawn on every contact panel, ordered
-    ///         exactly as the server orders a contact's own readouts (by Order, then id).
-    ///         Cached: the prototype set does not change mid round and rebuilding it per
-    ///         contact per frame would allocate inside the draw loop.
+    ///     The full roster, not only detected lines: labels are a fixed panel, so an
+    ///         unresolved quantity reads as a dimmed blank slot instead of dropping its
+    ///         row and shifting the stack; AlwaysShowLabel off means value-only.
     /// </summary>
-    private List<KsSensorIntelPrototype> KsIntelRoster()
+    private void KsRebuildRosterLines()
+    {
+        _ksRosterLines.Clear();
+
+        if (_ksContacts == null)
+            return;
+
+        var noValue = Loc.GetString("ks-sensor-intel-no-value");
+
+        foreach (var contact in _ksContacts)
+        {
+            List<(KsContactDetail Detail, bool HasValue, string Text)>? lines = null;
+
+            foreach (var (proto, label) in KsIntelRoster())
+            {
+                string? value = null;
+                foreach (var (intelId, v) in contact.Intel)
+                {
+                    if (intelId.Id == proto.ID)
+                    {
+                        value = v;
+                        break;
+                    }
+                }
+
+                if (value == null && !proto.AlwaysShowLabel)
+                    continue;
+
+                lines ??= new();
+                lines.Add((proto.Detail, value != null, $"{label}: {value ?? noValue}"));
+            }
+
+            if (lines != null)
+                _ksRosterLines[contact.Grid] = lines;
+        }
+    }
+
+    /// <summary>
+    ///     The fixed roster of readout labels drawn on every contact panel, ordered
+    ///         exactly as the server orders a contact's own readouts (by Order, then id),
+    ///         each with its localized label. Cached: the prototype set and its labels do
+    ///         not change mid round.
+    /// </summary>
+    private List<(KsSensorIntelPrototype Proto, string Label)> KsIntelRoster()
     {
         if (_ksIntelRoster != null)
             return _ksIntelRoster;
 
-        _ksIntelRoster = new List<KsSensorIntelPrototype>();
+        _ksIntelRoster = new List<(KsSensorIntelPrototype, string)>();
         foreach (var proto in _protoManager.EnumeratePrototypes<KsSensorIntelPrototype>())
-            _ksIntelRoster.Add(proto);
+            _ksIntelRoster.Add((proto, Loc.GetString(proto.Label)));
 
         _ksIntelRoster.Sort((a, b) =>
-            a.Order != b.Order ? a.Order.CompareTo(b.Order) : string.CompareOrdinal(a.ID, b.ID));
+            a.Proto.Order != b.Proto.Order ? a.Proto.Order.CompareTo(b.Proto.Order) : string.CompareOrdinal(a.Proto.ID, b.Proto.ID));
 
         return _ksIntelRoster;
     }
@@ -969,9 +1114,9 @@ public sealed partial class KsRadarControl : BaseShuttleControl
 
         var lines = new List<(string Text, Color Color)>
         {
-            (best.Name ?? Loc.GetString("ks-sensor-contact-unknown"), KsHud.TooltipText),
+            (best.Name ?? _ksUnknownText, KsHud.TooltipText),
             best.Live
-                ? (Loc.GetString("ks-sensor-contact-live"), KsHud.Live)
+                ? (_ksLiveText, KsHud.Live)
                 : (Loc.GetString("ks-sensor-contact-last-seen", ("seconds", (int)Math.Max(0, (curTime - best.LastSeen).TotalSeconds))), KsHud.Memory),
             (whereLine, KsHud.TooltipDetail),
         };
@@ -1054,14 +1199,14 @@ public sealed partial class KsRadarControl : BaseShuttleControl
                     : KsHud.ConePulse.Eval(_timing.CurTime.TotalSeconds)
                 : 1f;
 
-            var verts = KsRegionDraw.BuildVerts(region, gridToView, worldToView);
+            var count = KsRegionDraw.BuildVerts(region, gridToView, worldToView, ref _ksRegionVerts);
 
             // verts[0] is the apex: the fan fills the star-shaped cone in Filled mode,
             // and the boundary stroke skips the apex.
             if (mode == KsCoverageDisplayMode.Filled)
-                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, verts, tint.WithAlpha(KsHud.ConeFillAlpha * pulse));
+                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, _ksRegionVerts.AsSpan(0, count), tint.WithAlpha(KsHud.ConeFillAlpha * pulse));
 
-            handle.DrawPrimitives(DrawPrimitiveTopology.LineStrip, verts.AsSpan(1), tint.WithAlpha(KsHud.ConeLineAlpha * pulse));
+            handle.DrawPrimitives(DrawPrimitiveTopology.LineStrip, _ksRegionVerts.AsSpan(1, count - 1), tint.WithAlpha(KsHud.ConeLineAlpha * pulse));
         }
     }
 
@@ -1121,7 +1266,7 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         if (!_ksJammed)
             return;
 
-        var text = Loc.GetString("ks-sensor-jammed");
+        var text = _ksJammedText;
         var scale = KsHud.JammedTextScale;
         var dims = handle.GetDimensions(_ksFont, text, scale);
         var pos = new Vector2((PixelSize.X - dims.X) / 2f, 6f * UIScale);
@@ -1132,15 +1277,17 @@ public sealed partial class KsRadarControl : BaseShuttleControl
         handle.DrawString(_ksFont, pos, text, scale, KsHud.JammedColor.WithAlpha(Math.Clamp(pulse, 0f, 1f)));
     }
 
-    private void KsDrawInterests(DrawingHandleScreen handle, Matrix3x2 curGridToViewMatrix, Box2 viewAABB, Entity<MapGridComponent> gridEntity)
+    private void KsDrawInterests(DrawingHandleScreen handle, Matrix3x2 curGridToViewMatrix, Entity<MapGridComponent> gridEntity)
     {
         foreach (var (_, interest) in _radarInterestSystem.StaticInterests)
         {
             if (gridEntity.Owner != interest.Item2)
                 continue;
 
+            // Control pixels, so the cull box is the control: the old test compared
+            // pixels to a world-metres box.
             var interestPosition = Vector2.Transform(interest.Item3, curGridToViewMatrix);
-            if (!viewAABB.Contains(interestPosition))
+            if (!new UIBox2(Vector2.Zero, PixelSize).Contains(interestPosition))
                 continue;
 
             handle.DrawCircle(interestPosition, 5, Color.ToSrgb(KsHud.Interest), true);

--- a/Content.Client/_KS14/Shuttles/UI/KsRegionDraw.cs
+++ b/Content.Client/_KS14/Shuttles/UI/KsRegionDraw.cs
@@ -1,10 +1,11 @@
 using System.Numerics;
 using Content.Shared._KS14.Sensors;
+using Robust.Shared.Utility;
 
 namespace Content.Client._KS14.Shuttles.UI;
 
 /// <summary>
-///     Builds a coverage region's screen-space vertex array: the apex through the
+///     Builds a coverage region's screen-space vertices: the apex through the
 ///         grid matrix (it rides the ship), and the boundary either as world-oriented
 ///         offsets from the apex (a sensor fan, see
 ///         <see cref="KsSensorRegionState.WorldOffsets"/>) or through the same grid
@@ -14,20 +15,26 @@ namespace Content.Client._KS14.Shuttles.UI;
 /// </summary>
 public static class KsRegionDraw
 {
-    public static Vector2[] BuildVerts(KsSensorRegionState region, Matrix3x2 gridToView, Matrix3x2 worldToView)
+    /// <summary>
+    ///     Fills caller-owned scratch and returns the count (a fresh array per region
+    ///         per frame was pure churn); slice draws by the count, the tail may be stale.
+    /// </summary>
+    public static int BuildVerts(KsSensorRegionState region, Matrix3x2 gridToView, Matrix3x2 worldToView, ref Vector2[] into)
     {
-        var verts = new Vector2[region.Points.Count];
-        var apexView = Vector2.Transform(region.Points[0], gridToView);
-        verts[0] = apexView;
+        var count = region.Points.Count;
+        Extensions.EnsureLength(ref into, count);
 
-        for (var i = 1; i < verts.Length; i++)
+        var apexView = Vector2.Transform(region.Points[0], gridToView);
+        into[0] = apexView;
+
+        for (var i = 1; i < count; i++)
         {
-            verts[i] = region.WorldOffsets
+            into[i] = region.WorldOffsets
                 ? apexView + Vector2.TransformNormal(region.Points[i], worldToView)
                 : Vector2.Transform(region.Points[i], gridToView);
         }
 
-        return verts;
+        return count;
     }
 
     // A between-push ease of these polygons was tried and removed: eased cones read

--- a/Content.Client/_KS14/Shuttles/UI/KsShuttleMapControl.xaml.cs
+++ b/Content.Client/_KS14/Shuttles/UI/KsShuttleMapControl.xaml.cs
@@ -320,6 +320,9 @@ public sealed partial class KsShuttleMapControl : BaseShuttleControl
         }
     }
 
+    /// <summary>Per-frame scratch for the cone vertices, sliced by BuildVerts' returned count.</summary>
+    private Vector2[] _ksConeVerts = Array.Empty<Vector2>();
+
     /// <summary>
     ///     The network's coverage cones, own and datalink-relayed alike: every apex
     ///         arrives framed against the console's grid, so one matrix chain places
@@ -348,11 +351,11 @@ public sealed partial class KsShuttleMapControl : BaseShuttleControl
                     : KsHud.ConePulse.Eval(_timing.CurTime.TotalSeconds)
                 : 1f;
 
-            var verts = KsRegionDraw.BuildVerts(region, gridToView, worldToView);
+            var count = KsRegionDraw.BuildVerts(region, gridToView, worldToView, ref _ksConeVerts);
 
             // verts[0] is the apex: the fan fills the cone, the stroked boundary skips it.
-            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, verts, tint.WithAlpha(KsHud.ConeFillAlpha * pulse));
-            handle.DrawPrimitives(DrawPrimitiveTopology.LineStrip, verts.AsSpan(1), tint.WithAlpha(KsHud.ConeLineAlpha * pulse));
+            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, _ksConeVerts.AsSpan(0, count), tint.WithAlpha(KsHud.ConeFillAlpha * pulse));
+            handle.DrawPrimitives(DrawPrimitiveTopology.LineStrip, _ksConeVerts.AsSpan(1, count - 1), tint.WithAlpha(KsHud.ConeLineAlpha * pulse));
         }
     }
 

--- a/Content.IntegrationTests/Tests/_KS14/Sensors/KsIrstLifeSignTest.cs
+++ b/Content.IntegrationTests/Tests/_KS14/Sensors/KsIrstLifeSignTest.cs
@@ -1,0 +1,627 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._KS14.Sensors;
+using Content.Server.Shuttles.Systems;
+using Content.Shared._KS14.Sensors;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Shuttles.BUIStates;
+using Content.Shared.Shuttles.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics.Components;
+using Robust.UnitTesting.Pool;
+
+namespace Content.IntegrationTests.Tests._KS14.Sensors;
+
+/// <summary>
+///     IRST life signs: the heat of living bodies read on top of the hull picture.
+///         A creature aboard a hull the sweep already tracks blips grid-locally (the
+///         hull track is the resolution), a gridless one is a bare point source gated
+///         by range and line of sight, and everything else - crew in a cold hull, own
+///         crew, the dead, a relayed picture - stays dark.
+/// </summary>
+public sealed class KsIrstLifeSignTest : GameTest
+{
+    // Every case reads the replicated console BUI state, which needs the console
+    // opened server-side on a disconnected pair.
+    public override PoolSettings PoolSettings => PsDisconnected;
+
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: KsLifeSignTestSensor
+  name: test irst array
+  components:
+  - type: KsSensor
+    sensorType: IRST
+    maxRange: 100
+    providesName: false
+    requireExternalMount: false
+    intel:
+    - KsIntelHeat
+  - type: KsIrst
+    minDetectable: 10
+    minDetectableAtMaxRange: 80
+    factor: 2
+
+# Corner-mounted, so the grid signature is 5x this: 100, far above the floor.
+- type: entity
+  id: KsLifeSignTestWallHot
+  name: test hot wall
+  components:
+  - type: KsThermalSource
+    signature: 20
+
+- type: entity
+  id: KsLifeSignTestOccluder
+  name: test occluder
+  components:
+  - type: Occluder
+
+# Bare creature: MobState defaults to Alive, which is all a life sign needs.
+- type: entity
+  id: KsLifeSignTestMob
+  name: test creature
+  components:
+  - type: MobState
+
+- type: entity
+  id: KsLifeSignTestConsole
+  name: test shuttle console
+  components:
+  - type: ShuttleConsole
+  - type: RadarConsole
+  - type: KsSensorConsole
+  - type: UserInterface
+    interfaces:
+      enum.ShuttleConsoleUiKey.Key:
+        type: ShuttleConsoleBoundUserInterface
+
+# Stock datalink configuration: frequency 1200, AnnounceSelf and RelayContacts on.
+- type: entity
+  id: KsLifeSignTestTx
+  name: test datalink transmitter
+  components:
+  - type: KsDatalinkTransmitter
+    maxRange: 1000
+
+- type: entity
+  id: KsLifeSignTestRx
+  name: test datalink receiver
+  components:
+  - type: KsDatalinkReceiver
+";
+
+    /// <summary>
+    ///     Crew aboard a tracked hull blip once each, framed centre-of-mass-relative in
+    ///         that hull's local space so the dots ride its dead-reckoned contact. A
+    ///         corpse radiates nothing the system cares about, so it contributes no dot.
+    /// </summary>
+    [Test]
+    public async Task TestAboardCreaturesBlipWithGridLocalOffsets()
+    {
+        var server = Pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+        var uiSystem = entManager.System<SharedUserInterfaceSystem>();
+        var mobState = entManager.System<MobStateSystem>();
+
+        var map = await Pair.CreateTestMap();
+
+        var gridA = default(Entity<MapGridComponent>);
+        var gridB = default(Entity<MapGridComponent>);
+        var console = default(EntityUid);
+        var mobOne = default(EntityUid);
+        var mobTwo = default(EntityUid);
+
+        await server.WaitPost(() =>
+        {
+            entManager.DeleteEntity(map.Grid);
+
+            gridA = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+            gridB = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+
+            // Off the shared origin BEFORE anything mounts, or the crew parents to the
+            // wrong grid. 30 is well inside the IRST's 100 reach at signature 100.
+            xformSystem.SetLocalPosition(gridB.Owner, new Vector2(30f, 0f));
+
+            SpawnThermalWall(entManager, xformSystem, "KsLifeSignTestWallHot", gridB.Owner, 0, 0);
+
+            mobOne = entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridB.Owner, new Vector2(1.5f, 1.5f)));
+            mobTwo = entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridB.Owner, new Vector2(6.5f, 2.5f)));
+
+            var corpse = entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridB.Owner, new Vector2(3.5f, 5.5f)));
+            mobState.ChangeMobState(corpse, MobState.Dead);
+
+            console = SpawnConsole(entManager, xformSystem, uiSystem, gridA.Owner);
+            entManager.SpawnEntity("KsLifeSignTestSensor", new EntityCoordinates(gridA.Owner, new Vector2(0.5f, 0.5f)));
+        });
+
+        await Pair.RunTicksSync(60);
+
+        await server.WaitAssertion(() =>
+        {
+            var gridBNet = entManager.GetNetEntity(gridB.Owner);
+            var signs = GetLifeSigns(entManager, uiSystem, console);
+
+            Assert.That(signs, Is.Not.Null, "the tracked hull's crew never reached the console");
+            Assert.That(signs!, Has.Count.EqualTo(2),
+                "exactly the two living crew should blip: the corpse is not a life sign");
+
+            var localCenter = entManager.GetComponent<PhysicsComponent>(gridB.Owner).LocalCenter;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(signs.All(s => s.Grid == gridBNet),
+                    "an aboard life sign must be anchored to the hull it rides");
+
+                foreach (var mob in new[] { mobOne, mobTwo })
+                {
+                    var expected = entManager.GetComponent<TransformComponent>(mob).LocalPosition - localCenter;
+                    Assert.That(signs.Any(s => (s.Position - expected).Length() < 0.1f),
+                        $"no life sign sat at the crewman's centre-of-mass-relative offset {expected}");
+                }
+            });
+        });
+    }
+
+    /// <summary>
+    ///     Running cold conceals a crew: a hull under the sensitivity floor is never a
+    ///         contact, and the bodies inside it are resolved through that contact, so
+    ///         they vanish with it.
+    /// </summary>
+    [Test]
+    public async Task TestColdGridConcealsCrew()
+    {
+        var server = Pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+        var uiSystem = entManager.System<SharedUserInterfaceSystem>();
+
+        var map = await Pair.CreateTestMap();
+
+        var gridA = default(Entity<MapGridComponent>);
+        var gridCold = default(Entity<MapGridComponent>);
+        var console = default(EntityUid);
+
+        await server.WaitPost(() =>
+        {
+            entManager.DeleteEntity(map.Grid);
+
+            gridA = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+            gridCold = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+
+            // In range, but it carries no thermal source at all (signature 0, under the
+            // sensor's floor of 10), so the sweep can never resolve the hull.
+            xformSystem.SetLocalPosition(gridCold.Owner, new Vector2(30f, 0f));
+
+            entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridCold.Owner, new Vector2(1.5f, 1.5f)));
+
+            console = SpawnConsole(entManager, xformSystem, uiSystem, gridA.Owner);
+            entManager.SpawnEntity("KsLifeSignTestSensor", new EntityCoordinates(gridA.Owner, new Vector2(0.5f, 0.5f)));
+        });
+
+        await Pair.RunTicksSync(60);
+
+        await server.WaitAssertion(() =>
+        {
+            var coldNet = entManager.GetNetEntity(gridCold.Owner);
+
+            Assert.That(uiSystem.TryGetUiState<ShuttleBoundUserInterfaceState>(console, ShuttleConsoleUiKey.Key, out var state),
+                "console has no replicated BUI state");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(state!.NavState.KsSensorNav?.Contacts?.Any(c => c.Grid == coldNet) ?? false, Is.False,
+                    "a hull under the sensitivity floor must never be a contact");
+                Assert.That(state.NavState.KsSensorNav?.LifeSigns, Is.Null,
+                    "crew inside a hull the IRST cannot perceive must stay hidden");
+            });
+        });
+    }
+
+    /// <summary>
+    ///     The sweep skips its own hull, so the ship's own crew is never charted: the
+    ///         picture is what the array sees outside, not a crew monitor.
+    /// </summary>
+    [Test]
+    public async Task TestOwnGridCrewNeverBlips()
+    {
+        var server = Pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+        var uiSystem = entManager.System<SharedUserInterfaceSystem>();
+
+        var map = await Pair.CreateTestMap();
+
+        var gridA = default(Entity<MapGridComponent>);
+        var gridB = default(Entity<MapGridComponent>);
+        var console = default(EntityUid);
+
+        await server.WaitPost(() =>
+        {
+            entManager.DeleteEntity(map.Grid);
+
+            gridA = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+            gridB = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+
+            xformSystem.SetLocalPosition(gridB.Owner, new Vector2(30f, 0f));
+
+            // A hot target with its own crew, so the push definitely carries a life-sign
+            // list: without one the own-grid assertion would pass vacuously.
+            SpawnThermalWall(entManager, xformSystem, "KsLifeSignTestWallHot", gridB.Owner, 0, 0);
+            entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridB.Owner, new Vector2(1.5f, 1.5f)));
+
+            entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridA.Owner, new Vector2(4.5f, 4.5f)));
+
+            console = SpawnConsole(entManager, xformSystem, uiSystem, gridA.Owner);
+            entManager.SpawnEntity("KsLifeSignTestSensor", new EntityCoordinates(gridA.Owner, new Vector2(0.5f, 0.5f)));
+        });
+
+        await Pair.RunTicksSync(60);
+
+        await server.WaitAssertion(() =>
+        {
+            var gridANet = entManager.GetNetEntity(gridA.Owner);
+            var gridBNet = entManager.GetNetEntity(gridB.Owner);
+            var signs = GetLifeSigns(entManager, uiSystem, console);
+
+            Assert.That(signs, Is.Not.Null, "the target's crew should still have reached the console");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(signs!.Any(s => s.Grid == gridBNet), "the tracked target's crew must blip");
+                Assert.That(signs.Any(s => s.Grid == gridANet), Is.False,
+                    "the sensor's own crew must never be charted");
+                Assert.That(signs.Any(s => s.Grid == null), Is.False,
+                    "own-grid crew must not leak out as a free-floater either");
+            });
+        });
+    }
+
+    /// <summary>
+    ///     A gridless body is a bare point source: seen anywhere inside the array's full
+    ///         range with a clear line of sight, and nowhere else. All three cases here
+    ///         are identical creatures, so only geometry separates them.
+    /// </summary>
+    [Test]
+    public async Task TestFloaterRangeAndLos()
+    {
+        var server = Pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+        var uiSystem = entManager.System<SharedUserInterfaceSystem>();
+
+        var map = await Pair.CreateTestMap();
+
+        var gridA = default(Entity<MapGridComponent>);
+        var console = default(EntityUid);
+        var openPos = new Vector2(0.5f, 40f);
+        var shadowedPos = new Vector2(40f, 2f);
+        var distantPos = new Vector2(0.5f, 150f);
+
+        await server.WaitPost(() =>
+        {
+            entManager.DeleteEntity(map.Grid);
+
+            gridA = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+
+            entManager.SpawnEntity("KsLifeSignTestSensor", new EntityCoordinates(gridA.Owner, new Vector2(0.5f, 0.5f)));
+            console = SpawnConsole(entManager, xformSystem, uiSystem, gridA.Owner);
+
+            // An own-hull wall shadowing everything out along +X; +Y stays open.
+            SpawnOccluderColumn(entManager, gridA.Owner, 3, 0, 7);
+
+            entManager.SpawnEntity("KsLifeSignTestMob", new MapCoordinates(openPos, map.MapId));
+            entManager.SpawnEntity("KsLifeSignTestMob", new MapCoordinates(shadowedPos, map.MapId));
+            entManager.SpawnEntity("KsLifeSignTestMob", new MapCoordinates(distantPos, map.MapId));
+        });
+
+        await Pair.RunTicksSync(60);
+
+        await server.WaitAssertion(() =>
+        {
+            var signs = GetLifeSigns(entManager, uiSystem, console);
+            Assert.That(signs, Is.Not.Null, "the floater in the open never reached the console");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(signs!, Has.Count.EqualTo(1),
+                    "only the floater in clear view and in range may blip");
+                Assert.That(signs[0].Grid, Is.Null, "a gridless body carries no hull to ride");
+                Assert.That((signs[0].Position - openPos).Length(), Is.LessThan(0.1f),
+                    "a floater is charted at its world position");
+            });
+        });
+    }
+
+    /// <summary>
+    ///     Life signs are sweep-fresh, never remembered: the moment the array stops
+    ///         resolving a hull the crew dots go out, even though the hull itself
+    ///         lingers as an unconfirmed IRST memory ghost.
+    /// </summary>
+    [Test]
+    public async Task TestLifeSignsVanishWhenTrackGoesGhost()
+    {
+        var server = Pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+        var uiSystem = entManager.System<SharedUserInterfaceSystem>();
+
+        var map = await Pair.CreateTestMap();
+
+        var gridA = default(Entity<MapGridComponent>);
+        var gridB = default(Entity<MapGridComponent>);
+        var console = default(EntityUid);
+        var sensor = default(EntityUid);
+
+        await server.WaitPost(() =>
+        {
+            entManager.DeleteEntity(map.Grid);
+
+            gridA = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+            gridB = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+
+            xformSystem.SetLocalPosition(gridB.Owner, new Vector2(30f, 0f));
+
+            SpawnThermalWall(entManager, xformSystem, "KsLifeSignTestWallHot", gridB.Owner, 0, 0);
+            entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridB.Owner, new Vector2(1.5f, 1.5f)));
+
+            console = SpawnConsole(entManager, xformSystem, uiSystem, gridA.Owner);
+            sensor = entManager.SpawnEntity("KsLifeSignTestSensor", new EntityCoordinates(gridA.Owner, new Vector2(0.5f, 0.5f)));
+        });
+
+        await Pair.RunTicksSync(60);
+
+        await server.WaitAssertion(() =>
+        {
+            var signs = GetLifeSigns(entManager, uiSystem, console);
+            Assert.That(signs, Is.Not.Null, "the tracked hull's crew should blip while the array sweeps");
+            Assert.That(signs!, Has.Count.EqualTo(1));
+        });
+
+        // Kill the array rather than the target, so the hull record is untouched: the
+        // contact must survive as a ghost while its crew dots do not.
+        await server.WaitPost(() =>
+        {
+            entManager.GetComponent<KsSensorComponent>(sensor).Enabled = false;
+        });
+
+        await Pair.RunTicksSync(120);
+
+        await server.WaitAssertion(() =>
+        {
+            var gridBNet = entManager.GetNetEntity(gridB.Owner);
+
+            Assert.That(uiSystem.TryGetUiState<ShuttleBoundUserInterfaceState>(console, ShuttleConsoleUiKey.Key, out var state),
+                "console has no replicated BUI state");
+
+            var contact = state!.NavState.KsSensorNav?.Contacts?.FirstOrDefault(c => c.Grid == gridBNet);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(contact, Is.Not.Null, "the IRST memory ghost of the hull must persist");
+                Assert.That(contact!.Live, Is.False, "the track should have decayed to a ghost");
+                Assert.That(state.NavState.KsSensorNav?.LifeSigns, Is.Null,
+                    "life signs must not outlive the sweep that resolved them");
+            });
+        });
+    }
+
+    /// <summary>
+    ///     Life signs are strictly the console grid's own IRST picture. An ally's
+    ///         datalink relays its contacts, and the receiver charts them, but the crew
+    ///         dots that came with them on the transmitting side do not travel.
+    /// </summary>
+    [Test]
+    public async Task TestNoDatalinkRelay()
+    {
+        var server = Pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+        var uiSystem = entManager.System<SharedUserInterfaceSystem>();
+
+        var map = await Pair.CreateTestMap();
+
+        var gridTx = default(Entity<MapGridComponent>);
+        var gridTarget = default(Entity<MapGridComponent>);
+        var gridRx = default(Entity<MapGridComponent>);
+        var console = default(EntityUid);
+
+        await server.WaitPost(() =>
+        {
+            entManager.DeleteEntity(map.Grid);
+
+            gridTx = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+            gridTarget = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+            gridRx = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+
+            // The target sits inside the transmitter's IRST reach; the receiver sits far
+            // outside it (so it can only ever know the target second-hand) but well
+            // inside the datalink's 1000-unit range.
+            xformSystem.SetLocalPosition(gridTarget.Owner, new Vector2(30f, 0f));
+            xformSystem.SetLocalPosition(gridRx.Owner, new Vector2(0f, 300f));
+
+            SpawnThermalWall(entManager, xformSystem, "KsLifeSignTestWallHot", gridTarget.Owner, 0, 0);
+            entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridTarget.Owner, new Vector2(1.5f, 1.5f)));
+
+            entManager.SpawnEntity("KsLifeSignTestSensor", new EntityCoordinates(gridTx.Owner, new Vector2(0.5f, 0.5f)));
+            entManager.SpawnEntity("KsLifeSignTestTx", new EntityCoordinates(gridTx.Owner, new Vector2(1.5f, 0.5f)));
+
+            entManager.SpawnEntity("KsLifeSignTestRx", new EntityCoordinates(gridRx.Owner, new Vector2(0.5f, 0.5f)));
+            console = SpawnConsole(entManager, xformSystem, uiSystem, gridRx.Owner);
+        });
+
+        await Pair.RunTicksSync(90);
+
+        await server.WaitAssertion(() =>
+        {
+            var targetNet = entManager.GetNetEntity(gridTarget.Owner);
+
+            // The transmitting grid did resolve the crew, so there was something to relay.
+            Assert.That(entManager.TryGetComponent<KsSensorContactPoolComponent>(gridTx.Owner, out var txPool),
+                "the IRST grid never built a contact pool");
+            Assert.That(txPool!.LifeSigns.ContainsKey(gridTarget.Owner),
+                "the transmitting grid should have resolved the target's crew itself");
+
+            Assert.That(uiSystem.TryGetUiState<ShuttleBoundUserInterfaceState>(console, ShuttleConsoleUiKey.Key, out var state),
+                "receiver console has no replicated BUI state");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(state!.NavState.KsSensorNav?.Contacts?.Any(c => c.Grid == targetNet) ?? false,
+                    "the relayed hull contact should reach the receiver");
+                Assert.That(state.NavState.KsSensorNav?.LifeSigns, Is.Null,
+                    "life signs must never ride the datalink");
+            });
+        });
+    }
+
+    /// <summary>
+    ///     A console refresh can land between a mid-tick map change (FTL refreshes
+    ///         consoles the moment the grid moves) and the next sweep's wipe. The
+    ///         scratch's coordinates mean nothing on the new map, so the snapshot must
+    ///         drop them rather than chart departure-map phantoms.
+    /// </summary>
+    [Test]
+    public async Task TestMapChangeDropsStaleLifeSigns()
+    {
+        var server = Pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var xformSystem = entManager.System<SharedTransformSystem>();
+        var uiSystem = entManager.System<SharedUserInterfaceSystem>();
+        var consoleSystem = entManager.System<ShuttleConsoleSystem>();
+
+        var map = await Pair.CreateTestMap();
+
+        var gridA = default(Entity<MapGridComponent>);
+        var gridB = default(Entity<MapGridComponent>);
+        var console = default(EntityUid);
+
+        await server.WaitPost(() =>
+        {
+            entManager.DeleteEntity(map.Grid);
+
+            gridA = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+            gridB = MakeShipGrid(entManager, mapManager, mapSystem, map.MapId);
+
+            xformSystem.SetLocalPosition(gridB.Owner, new Vector2(30f, 0f));
+
+            SpawnThermalWall(entManager, xformSystem, "KsLifeSignTestWallHot", gridB.Owner, 0, 0);
+            entManager.SpawnEntity("KsLifeSignTestMob", new EntityCoordinates(gridB.Owner, new Vector2(1.5f, 1.5f)));
+
+            // A floater too: floaters ship raw world positions, the exact payload that
+            // must not survive the hop.
+            entManager.SpawnEntity("KsLifeSignTestMob", new MapCoordinates(new Vector2(0.5f, 40f), map.MapId));
+
+            console = SpawnConsole(entManager, xformSystem, uiSystem, gridA.Owner);
+            entManager.SpawnEntity("KsLifeSignTestSensor", new EntityCoordinates(gridA.Owner, new Vector2(0.5f, 0.5f)));
+        });
+
+        await Pair.RunTicksSync(60);
+
+        // Move, refresh and read inside one server callback: a sensor tick in between
+        // would wipe the scratch and let the assertion pass vacuously.
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(GetLifeSigns(entManager, uiSystem, console), Is.Not.Null,
+                "life signs should be flowing before the hop");
+
+            var newMap = mapSystem.CreateMap(out _);
+            xformSystem.SetCoordinates(gridA.Owner, new EntityCoordinates(newMap, Vector2.Zero));
+            consoleSystem.RefreshShuttleConsoles(gridA.Owner);
+
+            Assert.That(GetLifeSigns(entManager, uiSystem, console), Is.Null,
+                "a snapshot on the new map must not chart the old map's life signs");
+        });
+    }
+
+    private static List<KsLifeSignState>? GetLifeSigns(
+        IEntityManager entManager,
+        SharedUserInterfaceSystem uiSystem,
+        EntityUid console)
+    {
+        uiSystem.TryGetUiState<ShuttleBoundUserInterfaceState>(console, ShuttleConsoleUiKey.Key, out var state);
+        return state?.NavState.KsSensorNav?.LifeSigns;
+    }
+
+    /// <summary>Anchored and with its UI open: a closed or loose console carries no picture.</summary>
+    private static EntityUid SpawnConsole(
+        IEntityManager entManager,
+        SharedTransformSystem xformSystem,
+        SharedUserInterfaceSystem uiSystem,
+        EntityUid grid)
+    {
+        var console = entManager.SpawnEntity("KsLifeSignTestConsole", new EntityCoordinates(grid, new Vector2(2.5f, 0.5f)));
+        xformSystem.AnchorEntity((console, entManager.GetComponent<TransformComponent>(console)));
+
+        var actor = entManager.SpawnEntity(null, new EntityCoordinates(grid, new Vector2(2.5f, 0.5f)));
+        uiSystem.OpenUi(console, ShuttleConsoleUiKey.Key, actor);
+
+        return console;
+    }
+
+    /// <summary>8x8, big enough to clear the &lt;10 mass junk filter.</summary>
+    private static Entity<MapGridComponent> MakeShipGrid(
+        IEntityManager entManager,
+        IMapManager mapManager,
+        SharedMapSystem mapSystem,
+        MapId mapId)
+    {
+        var grid = mapManager.CreateGridEntity(mapId);
+
+        var tiles = new List<(Vector2i, Tile)>();
+        for (var x = 0; x < 8; x++)
+        {
+            for (var y = 0; y < 8; y++)
+            {
+                tiles.Add((new Vector2i(x, y), new Tile(1)));
+            }
+        }
+
+        mapSystem.SetTiles(grid.Owner, grid.Comp, tiles);
+        return grid;
+    }
+
+    /// <summary>Occluders need no anchoring to register in the occluder tree.</summary>
+    private static void SpawnOccluderColumn(IEntityManager entManager, EntityUid grid, int x, int yFrom, int yTo)
+    {
+        for (var y = yFrom; y <= yTo; y++)
+        {
+            entManager.SpawnEntity("KsLifeSignTestOccluder", new EntityCoordinates(grid, new Vector2(x, y)));
+        }
+    }
+
+    /// <summary>Must be anchored: the signature crawler only counts anchored hull walls, not carried or loose ones.</summary>
+    private static void SpawnThermalWall(
+        IEntityManager entManager,
+        SharedTransformSystem xformSystem,
+        string proto,
+        EntityUid grid,
+        int x,
+        int y)
+    {
+        var wall = entManager.SpawnEntity(proto, new EntityCoordinates(grid, new Vector2(x + 0.5f, y + 0.5f)));
+        xformSystem.AnchorEntity((wall, entManager.GetComponent<TransformComponent>(wall)));
+    }
+}

--- a/Content.Server/_KS14/Sensors/KsIrstSystem.cs
+++ b/Content.Server/_KS14/Sensors/KsIrstSystem.cs
@@ -1,5 +1,7 @@
 using System.Numerics;
 using Content.Shared._KS14.Sensors;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 
@@ -34,6 +36,9 @@ public sealed partial class KsIrstSystem : KsLosSensorSystem
     ///         through them. The sensor's own grid is never added, so it still blocks.
     /// </summary>
     private readonly HashSet<EntityUid> _transparentGrids = new();
+
+    /// <summary>Sweep scratch: detected grids, with what frames their life signs grid-locally.</summary>
+    private readonly Dictionary<EntityUid, (Matrix3x2 InvMatrix, Vector2 LocalCenter)> _lifeSignFrames = new();
 
     public override void Initialize()
     {
@@ -90,6 +95,8 @@ public sealed partial class KsIrstSystem : KsLosSensorSystem
 
         // A target's per-signature effective range only ever shrinks inside this broadphase box.
         BuildTransparentSet(mapId, sensorPos, maxRange, ownGrid ?? default, PerceptionFloor(ent.Comp, maxRange));
+
+        _lifeSignFrames.Clear();
 
         foreach (var grid in Grids)
         {
@@ -150,6 +157,52 @@ public sealed partial class KsIrstSystem : KsLosSensorSystem
                 physics.LocalCenter,
                 MetaData(gridUid).EntityName,
                 intel));
+
+            _lifeSignFrames[gridUid] = (XformSystem.GetInvWorldMatrix(gridUid), physics.LocalCenter);
+        }
+
+        CollectLifeSigns(mapId, sensorPos, maxRange, ownGrid ?? default, ref args);
+    }
+
+    /// <summary>
+    ///     Aboard a detected grid the hull track is the resolution: no per-creature
+    ///         ray, offsets grid-local so dots ride the dead-reckoned contact. A
+    ///         free-floater is a point source: full range, no taper, same occluder LOS
+    ///         as a grid. Cold hulls and junk grids conceal their riders.
+    /// </summary>
+    private void CollectLifeSigns(MapId mapId, Vector2 sensorPos, float maxRange, EntityUid ownGrid, ref KsSensorSweepEvent args)
+    {
+        var rangeSq = maxRange * maxRange;
+
+        var query = AllEntityQuery<MobStateComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var mob, out var xform))
+        {
+            if (mob.CurrentState == MobState.Dead || xform.MapID != mapId)
+                continue;
+
+            if (xform.GridUid is { } mobGrid)
+            {
+                if (!_lifeSignFrames.TryGetValue(mobGrid, out var frame))
+                    continue;
+
+                var offset = Vector2.Transform(XformSystem.GetWorldPosition(xform), frame.InvMatrix) - frame.LocalCenter;
+                args.LifeSigns ??= new();
+                if (!args.LifeSigns.TryGetValue(mobGrid, out var offsets))
+                    args.LifeSigns[mobGrid] = offsets = new();
+                offsets.Add(offset);
+                continue;
+            }
+
+            var worldPos = XformSystem.GetWorldPosition(xform);
+            if ((worldPos - sensorPos).LengthSquared() > rangeSq)
+                continue;
+
+            // No target grid to ignore: a floater occludes nothing, not even itself.
+            if (!HasLos(mapId, sensorPos, worldPos, default, ownGrid, _transparentGrids))
+                continue;
+
+            args.LifeSignFloaters ??= new();
+            args.LifeSignFloaters.TryAdd(uid, worldPos);
         }
     }
 

--- a/Content.Server/_KS14/Sensors/KsLosSensorSystem.cs
+++ b/Content.Server/_KS14/Sensors/KsLosSensorSystem.cs
@@ -90,17 +90,24 @@ public abstract partial class KsLosSensorSystem : EntitySystem
     }
 
     /// <summary>
-    ///     The single-hit ray cast returns the first hit in traversal order, not the
-    ///         nearest, so we collect every hit and take the minimum. The ray bleeds through
-    ///         <paramref name="transparent"/> grids (save <paramref name="ownGrid"/>)
-    ///         exactly as detection does.
+    ///     The single-hit cast returns the first hit in traversal order, not the
+    ///         nearest - but it terminates the walk where the list overload drags the
+    ///         whole corridor. So: probe to bound the ray, then collect within that
+    ///         bound and take the minimum (the nearest hit cannot lie past the probe's).
+    ///         Bleeds through <paramref name="transparent"/> grids exactly as detection does.
     /// </summary>
     private float CastReach(MapId mapId, Vector2 origin, Vector2 dir, float range, EntityUid ownGrid = default, HashSet<EntityUid>? transparent = null)
     {
-        _hits.Clear();
-        Occluder.IntersectRay(_hits, mapId, new Ray(origin, dir), range, new LosIgnoreState(EntityUid.Invalid, ownGrid, transparent), LosIgnore);
+        var ray = new Ray(origin, dir);
+        var state = new LosIgnoreState(EntityUid.Invalid, ownGrid, transparent);
 
-        var reach = range;
+        if (Occluder.IntersectRay(mapId, ray, range, state, LosIgnore) is not { } first)
+            return range;
+
+        _hits.Clear();
+        Occluder.IntersectRay(_hits, mapId, ray, first.Distance, state, LosIgnore);
+
+        var reach = first.Distance;
         foreach (var hit in _hits)
         {
             if (hit.Distance < reach)

--- a/Content.Server/_KS14/Sensors/KsSensorConsoleSystem.cs
+++ b/Content.Server/_KS14/Sensors/KsSensorConsoleSystem.cs
@@ -116,6 +116,7 @@ public sealed partial class KsSensorConsoleSystem : EntitySystem
             ElintDeaf = collectEv.ElintDeaf,
             HasRwr = collectEv.HasRwr,
             EmissionLog = collectEv.EmissionLog,
+            LifeSigns = collectEv.LifeSigns,
         };
     }
 }

--- a/Content.Server/_KS14/Sensors/KsSensorContactPoolComponent.cs
+++ b/Content.Server/_KS14/Sensors/KsSensorContactPoolComponent.cs
@@ -41,6 +41,24 @@ public sealed partial class KsSensorContactPoolComponent : Component
     /// </summary>
     [ViewVariables]
     public List<KsEmissionLogEntry> EmissionLog = new();
+
+    /// <summary>
+    ///     Aboard life-sign offsets by tracked grid (centre-of-mass-relative, local).
+    ///         Sweep scratch, wiped every tick: never expired, never relayed.
+    /// </summary>
+    [ViewVariables]
+    public Dictionary<EntityUid, List<Vector2>> LifeSigns = new();
+
+    /// <summary>Free-floating life signs this sweep, keyed by creature (dedupes co-mounted IRSTs); values are world positions. Sweep scratch like <see cref="LifeSigns"/>.</summary>
+    [ViewVariables]
+    public Dictionary<EntityUid, Vector2> LifeSignFloaters = new();
+
+    /// <summary>
+    ///     Map the scratch was swept on: a console refresh can land between a mid-tick
+    ///         map change (FTL) and the next sweep's wipe. Mirrors <see cref="KsContactRecord.MapId"/>.
+    /// </summary>
+    [ViewVariables]
+    public MapId LifeSignsMapId = MapId.Nullspace;
 }
 
 /// <summary>Server-side record of one known contact; positional data always holds the freshest knowledge across all sources.</summary>

--- a/Content.Server/_KS14/Sensors/KsSensorEvents.cs
+++ b/Content.Server/_KS14/Sensors/KsSensorEvents.cs
@@ -55,6 +55,12 @@ public readonly record struct KsSensorDetection(
 public record struct KsSensorSweepEvent(Entity<KsSensorComponent> Sensor)
 {
     public readonly List<KsSensorDetection> Detections = [];
+
+    /// <summary>Aboard life signs by target grid, centre-of-mass-relative local offsets (the frame the client dead-reckons in). Null for sensors without life-sign resolution.</summary>
+    public Dictionary<EntityUid, List<Vector2>>? LifeSigns;
+
+    /// <summary>Free-floating life signs by creature (co-mounted sensors dedupe), world positions.</summary>
+    public Dictionary<EntityUid, Vector2>? LifeSignFloaters;
 }
 
 /// <summary>
@@ -129,6 +135,9 @@ public record struct KsCollectNavContactsEvent(EntityUid? Grid)
 
     /// <summary>The grid's emission log (oldest first), or null when it is empty. See <see cref="KsSensorNavState.EmissionLog"/>.</summary>
     public List<KsEmissionLogEntry>? EmissionLog;
+
+    /// <summary>This sweep's life-sign blips, or null when there are none. See <see cref="KsSensorNavState.LifeSigns"/>.</summary>
+    public List<KsLifeSignState>? LifeSigns;
 }
 
 /// <summary>

--- a/Content.Server/_KS14/Sensors/KsSensorIntelSystem.cs
+++ b/Content.Server/_KS14/Sensors/KsSensorIntelSystem.cs
@@ -36,16 +36,12 @@ public sealed partial class KsSensorIntelSystem : EntitySystem
     private readonly Dictionary<EntityUid, float> _thrustCache = new();
     private GameTick _thrustCacheTick = GameTick.Zero;
 
-    // Both signatures are summed over EVERY exterior wall in the game, so the same
-    // one-pass-per-tick cache as thrust: an IRST sweep asks for many grids' signatures
-    // each tick and the HEAT readout asks again.
-    // They share one build because they share the expensive half: heat and radar
-    // cross-section are independent per-wall values, but the exposed-sides count that
-    // scales both is the same 8 tile lookups, and in practice the same walls carry both
-    // components.
+    // Per-grid totals, recomputed only when the grid's skin geometry changes: the old
+    // per-tick crawl re-walked every wall in the game (~2ms, station-size-unbounded).
+    // One shared build: heat and RCS differ per wall but share the 8-tile exposure count.
     private readonly Dictionary<EntityUid, float> _thermalCache = new();
     private readonly Dictionary<EntityUid, float> _radarCache = new();
-    private GameTick _signatureCacheTick = GameTick.Zero;
+    private readonly HashSet<EntityUid> _dirtySignatureGrids = new();
 
     /// <summary>
     ///     The eight surrounding tiles (four faces + four corners) checked for space
@@ -69,6 +65,56 @@ public sealed partial class KsSensorIntelSystem : EntitySystem
         _gridQuery = GetEntityQuery<MapGridComponent>();
         _thermalSourceQuery = GetEntityQuery<KsThermalSourceComponent>();
         _radarSourceQuery = GetEntityQuery<KsRadarSourceComponent>();
+
+        // The full geometry-change surface: walls entering/leaving the hull, and tile
+        // changes (exposure counts space TILES, so wall placement alone never changes
+        // a neighbour's). Signature values never mutate at runtime.
+        SubscribeLocalEvent<KsThermalSourceComponent, ComponentStartup>(OnThermalSourceLifecycle);
+        SubscribeLocalEvent<KsThermalSourceComponent, ComponentShutdown>(OnThermalSourceLifecycle);
+        SubscribeLocalEvent<KsThermalSourceComponent, AnchorStateChangedEvent>(OnThermalSourceAnchor);
+        SubscribeLocalEvent<KsThermalSourceComponent, ReAnchorEvent>(OnThermalSourceReAnchor);
+        SubscribeLocalEvent<KsRadarSourceComponent, ComponentStartup>(OnRadarSourceLifecycle);
+        SubscribeLocalEvent<KsRadarSourceComponent, ComponentShutdown>(OnRadarSourceLifecycle);
+        SubscribeLocalEvent<KsRadarSourceComponent, AnchorStateChangedEvent>(OnRadarSourceAnchor);
+        SubscribeLocalEvent<KsRadarSourceComponent, ReAnchorEvent>(OnRadarSourceReAnchor);
+        SubscribeLocalEvent<MapGridComponent, TileChangedEvent>(OnGridTileChanged);
+        // Not <MapGridComponent, ComponentShutdown>: lifecycle events allow one
+        // handler per component type game-wide, and the map system owns that one.
+        SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoval);
+    }
+
+    private void OnThermalSourceLifecycle(EntityUid uid, KsThermalSourceComponent comp, ComponentStartup args) => DirtySignatureGrid(uid);
+    private void OnThermalSourceLifecycle(EntityUid uid, KsThermalSourceComponent comp, ComponentShutdown args) => DirtySignatureGrid(uid);
+    private void OnThermalSourceAnchor(EntityUid uid, KsThermalSourceComponent comp, ref AnchorStateChangedEvent args) => DirtySignatureGrid(uid);
+    private void OnRadarSourceLifecycle(EntityUid uid, KsRadarSourceComponent comp, ComponentStartup args) => DirtySignatureGrid(uid);
+    private void OnRadarSourceLifecycle(EntityUid uid, KsRadarSourceComponent comp, ComponentShutdown args) => DirtySignatureGrid(uid);
+    private void OnRadarSourceAnchor(EntityUid uid, KsRadarSourceComponent comp, ref AnchorStateChangedEvent args) => DirtySignatureGrid(uid);
+
+    private void OnThermalSourceReAnchor(EntityUid uid, KsThermalSourceComponent comp, ref ReAnchorEvent args)
+    {
+        _dirtySignatureGrids.Add(args.OldGrid);
+        _dirtySignatureGrids.Add(args.Grid);
+    }
+
+    private void OnRadarSourceReAnchor(EntityUid uid, KsRadarSourceComponent comp, ref ReAnchorEvent args)
+    {
+        _dirtySignatureGrids.Add(args.OldGrid);
+        _dirtySignatureGrids.Add(args.Grid);
+    }
+
+    private void OnGridTileChanged(EntityUid uid, MapGridComponent comp, ref TileChangedEvent args) => _dirtySignatureGrids.Add(uid);
+
+    private void OnGridRemoval(GridRemovalEvent args)
+    {
+        _thermalCache.Remove(args.EntityUid);
+        _radarCache.Remove(args.EntityUid);
+        _dirtySignatureGrids.Remove(args.EntityUid);
+    }
+
+    private void DirtySignatureGrid(EntityUid wallUid)
+    {
+        if (Transform(wallUid).GridUid is { } grid)
+            _dirtySignatureGrids.Add(grid);
     }
 
     /// <summary>
@@ -77,11 +123,10 @@ public sealed partial class KsSensorIntelSystem : EntitySystem
     ///         neighbor tile). Interior walls are shielded and add nothing, so a boxed-in
     ///         hull runs colder than a sprawling one. This is what IRST detects and the HEAT
     ///         readout reports.
-    ///     Cached once per tick across all grids, so it costs nothing when nothing asks.
     /// </summary>
     public float GetThermalSignature(EntityUid grid)
     {
-        if (_signatureCacheTick != _timing.CurTick)
+        if (_dirtySignatureGrids.Count > 0)
             BuildSignatureCaches();
 
         return _thermalCache.GetValueOrDefault(grid);
@@ -96,27 +141,31 @@ public sealed partial class KsSensorIntelSystem : EntitySystem
     /// </summary>
     public float GetRadarSignature(EntityUid grid)
     {
-        if (_signatureCacheTick != _timing.CurTick)
+        if (_dirtySignatureGrids.Count > 0)
             BuildSignatureCaches();
 
         return _radarCache.GetValueOrDefault(grid);
     }
 
     /// <summary>
-    ///     Rebuilds both signature caches in one crawl of the game's exterior walls. Walls
-    ///         carrying both components (every stock wall does) are counted once into both
-    ///         caches; the second loop exists only so a wall carrying just one of the two is
-    ///         still summed, and it does no tile work for walls the first loop covered.
+    ///     Still one pass over all walls even though only dirty grids recompute:
+    ///         enumeration is cheap, the 8 tile lookups are not. The second loop only
+    ///         catches walls carrying just one of the two components.
     /// </summary>
     private void BuildSignatureCaches()
     {
-        _signatureCacheTick = _timing.CurTick;
-        _thermalCache.Clear();
-        _radarCache.Clear();
+        foreach (var grid in _dirtySignatureGrids)
+        {
+            _thermalCache.Remove(grid);
+            _radarCache.Remove(grid);
+        }
 
         var thermalQuery = AllEntityQuery<KsThermalSourceComponent, TransformComponent>();
         while (thermalQuery.MoveNext(out var uid, out var source, out var xform))
         {
+            if (xform.GridUid is not { } dirtyGrid || !_dirtySignatureGrids.Contains(dirtyGrid))
+                continue;
+
             var exposed = CountExposedSides(xform, out var gridUid);
             if (exposed == 0)
                 continue;
@@ -133,12 +182,17 @@ public sealed partial class KsSensorIntelSystem : EntitySystem
             if (_thermalSourceQuery.HasComponent(uid))
                 continue;
 
+            if (xform.GridUid is not { } dirtyGrid || !_dirtySignatureGrids.Contains(dirtyGrid))
+                continue;
+
             var exposed = CountExposedSides(xform, out var gridUid);
             if (exposed == 0)
                 continue;
 
             _radarCache[gridUid] = _radarCache.GetValueOrDefault(gridUid) + source.Signature * exposed;
         }
+
+        _dirtySignatureGrids.Clear();
     }
 
     /// <summary>

--- a/Content.Server/_KS14/Sensors/KsSensorSystem.cs
+++ b/Content.Server/_KS14/Sensors/KsSensorSystem.cs
@@ -91,6 +91,22 @@ public sealed partial class KsSensorSystem : EntitySystem
     /// </summary>
     private readonly Dictionary<EntityUid, HashSet<EntityUid>> _coverageLinks = new();
 
+    /// <summary>Last tick's links: forming/dying links redraw the picture while mutating no pool, and a receiver losing its LAST ally needs one push to clear the cone.</summary>
+    private readonly Dictionary<EntityUid, HashSet<EntityUid>> _lastCoverageLinks = new();
+
+    /// <summary>
+    ///     Relaying allies' poses as of the last change-mark: relayed cones are
+    ///         console-frame snapshots, so a moving ally must re-push its receivers.
+    ///         Measured against the last MARK so a slow drift still accumulates.
+    /// </summary>
+    private readonly Dictionary<EntityUid, (Vector2 Pos, Angle Yaw)> _lastLinkPose = new();
+
+    private readonly HashSet<EntityUid> _linkSourceScratch = new();
+    private readonly List<EntityUid> _poseEvictScratch = new();
+
+    /// <summary>Squared metres of ally drift that forces a receiver push; a parked grid moves exactly zero.</summary>
+    private const float LinkMoveEpsilonSq = 0.01f * 0.01f;
+
     /// <summary>
     ///     Per-tick cache of computed sensor coverage regions, so several
     ///         consoles on one grid share the (occluder-ray) work each push.
@@ -246,6 +262,9 @@ public sealed partial class KsSensorSystem : EntitySystem
 
         RunSweeps(curTime);
         RunDatalink(curTime);
+        // Outside RunDatalink: its no-transmitters early return must still let a
+        // dead network push its receivers one last clear.
+        MarkCoverageLinkChanges();
         RunExpiry(curTime);
 
         // Push fresh pictures to whoever is watching, but only if anything actually
@@ -257,11 +276,6 @@ public sealed partial class KsSensorSystem : EntitySystem
             anyChanged |= pool.Changed;
             pool.Changed = false;
         }
-
-        // Relayed coverage moves with the ALLY's hull, which mutates no pool: a
-        // linked network must keep pushing every tick or a quiet sector would
-        // freeze the allies' cones at their old console-local offsets.
-        anyChanged |= _coverageLinks.Count > 0;
 
         // These changes mutate no contact pool, so without folding the flag in here the
         // change-gated push would miss them and the console would show stale feedback
@@ -346,6 +360,19 @@ public sealed partial class KsSensorSystem : EntitySystem
 
     private void RunSweeps(TimeSpan curTime)
     {
+        // Life signs are sweep-fresh: wipe up front so a sweep that resolves nothing
+        // reads back as nothing, marking Changed so an emptied picture pushes once.
+        var lifeQuery = EntityQueryEnumerator<KsSensorContactPoolComponent>();
+        while (lifeQuery.MoveNext(out _, out var lifePool))
+        {
+            if (lifePool.LifeSigns.Count == 0 && lifePool.LifeSignFloaters.Count == 0)
+                continue;
+
+            lifePool.LifeSigns.Clear();
+            lifePool.LifeSignFloaters.Clear();
+            lifePool.Changed = true;
+        }
+
         var query = EntityQueryEnumerator<KsSensorComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var sensor, out var xform))
         {
@@ -361,10 +388,18 @@ public sealed partial class KsSensorSystem : EntitySystem
             var ev = new KsSensorSweepEvent((uid, sensor));
             RaiseLocalEvent(uid, ref ev);
 
-            if (ev.Detections.Count == 0)
+            var hasLifeSigns = ev.LifeSigns is { Count: > 0 } || ev.LifeSignFloaters is { Count: > 0 };
+            if (ev.Detections.Count == 0 && !hasLifeSigns)
                 continue;
 
             var pool = EnsureComp<KsSensorContactPoolComponent>(gridUid);
+
+            if (hasLifeSigns)
+                MergeLifeSigns(pool, ev.LifeSigns, ev.LifeSignFloaters, xform.MapID);
+
+            if (ev.Detections.Count == 0)
+                continue;
+
             var sensorName = Name(uid);
             var gridName = Name(gridUid);
             var mapId = xform.MapID;
@@ -480,6 +515,25 @@ public sealed partial class KsSensorSystem : EntitySystem
         }
 
         return false;
+    }
+
+    /// <summary>Co-tracking IRSTs report the same everyone-aboard list, so the first writer wins; floaters union by creature since lines of sight differ.</summary>
+    private static void MergeLifeSigns(KsSensorContactPoolComponent pool, Dictionary<EntityUid, List<Vector2>>? aboard, Dictionary<EntityUid, Vector2>? floaters, MapId mapId)
+    {
+        if (aboard != null)
+        {
+            foreach (var (grid, offsets) in aboard)
+                pool.LifeSigns.TryAdd(grid, offsets);
+        }
+
+        if (floaters != null)
+        {
+            foreach (var (creature, pos) in floaters)
+                pool.LifeSignFloaters.TryAdd(creature, pos);
+        }
+
+        pool.LifeSignsMapId = mapId;
+        pool.Changed = true;
     }
 
     private void MergeDetection(KsSensorContactPoolComponent pool, KsSensorDetection detection, KsSourceRecord source, MapId mapId)
@@ -686,6 +740,72 @@ public sealed partial class KsSensorSystem : EntitySystem
             if (heard > 0)
                 _heardTransmitters[rxUid] = heard;
         }
+    }
+
+    /// <summary>
+    ///     Marks receiver pools changed for network-picture changes no pool records;
+    ///         replaces blanket-pushing every console while any link existed anywhere.
+    /// </summary>
+    private void MarkCoverageLinkChanges()
+    {
+        foreach (var (rxGrid, allies) in _coverageLinks)
+        {
+            if (!_lastCoverageLinks.TryGetValue(rxGrid, out var old) || !old.SetEquals(allies))
+                MarkPoolChanged(rxGrid);
+        }
+
+        foreach (var rxGrid in _lastCoverageLinks.Keys)
+        {
+            if (!_coverageLinks.ContainsKey(rxGrid))
+                MarkPoolChanged(rxGrid);
+        }
+
+        _lastCoverageLinks.Clear();
+        _linkSourceScratch.Clear();
+        foreach (var (rxGrid, allies) in _coverageLinks)
+        {
+            _lastCoverageLinks[rxGrid] = new HashSet<EntityUid>(allies);
+            _linkSourceScratch.UnionWith(allies);
+        }
+
+        // Drop dead sources' bases so a returning ally starts fresh.
+        _poseEvictScratch.Clear();
+        foreach (var txGrid in _lastLinkPose.Keys)
+        {
+            if (!_linkSourceScratch.Contains(txGrid))
+                _poseEvictScratch.Add(txGrid);
+        }
+
+        foreach (var txGrid in _poseEvictScratch)
+            _lastLinkPose.Remove(txGrid);
+
+        foreach (var txGrid in _linkSourceScratch)
+        {
+            var (pos, rot) = _transform.GetWorldPositionRotation(txGrid);
+            if (_lastLinkPose.TryGetValue(txGrid, out var last))
+            {
+                if ((pos - last.Pos).LengthSquared() < LinkMoveEpsilonSq
+                    && Math.Abs(Angle.ShortestDistance(last.Yaw, rot).Theta) < YawPushEpsilon)
+                {
+                    continue;
+                }
+
+                foreach (var (rxGrid, allies) in _coverageLinks)
+                {
+                    if (allies.Contains(txGrid))
+                        MarkPoolChanged(rxGrid);
+                }
+            }
+            // A NEW source needs no mark (the link diff above covered it), only a base.
+
+            _lastLinkPose[txGrid] = (pos, rot);
+        }
+    }
+
+    private void MarkPoolChanged(EntityUid gridUid)
+    {
+        if (TryComp<KsSensorContactPoolComponent>(gridUid, out var pool))
+            pool.Changed = true;
     }
 
     /// <summary>
@@ -1157,6 +1277,12 @@ public sealed partial class KsSensorSystem : EntitySystem
             // ring mutates every tick.
             if (pool.EmissionLog.Count > 0)
                 ev.EmissionLog = new List<KsEmissionLogEntry>(pool.EmissionLog);
+
+            if ((pool.LifeSigns.Count > 0 || pool.LifeSignFloaters.Count > 0)
+                && pool.LifeSignsMapId == Transform(gridUid).MapID)
+            {
+                ev.LifeSigns = BuildLifeSignStates(pool, ev.Contacts);
+            }
         }
 
         ev.Regions = BuildSensorRegions(gridUid);
@@ -1170,6 +1296,41 @@ public sealed partial class KsSensorSystem : EntitySystem
         // Emission truth, not the toggles: an unpowered radar left switched on
         // reports RadarActive without actually deafening the ELINT.
         ev.ElintDeaf = ev.HasElint && IsGridEmitting(gridUid);
+    }
+
+    /// <summary>
+    ///     The wire carries bare positions, never identity. Aboard dots ship only for
+    ///         Exact-quality contacts the snapshot carries: gating client-side would
+    ///         let a modified client read the crew layout of a withheld hull.
+    /// </summary>
+    private List<KsLifeSignState>? BuildLifeSignStates(KsSensorContactPoolComponent pool, List<KsSensorContactState>? contacts)
+    {
+        var states = new List<KsLifeSignState>();
+
+        if (pool.LifeSigns.Count > 0 && contacts != null)
+        {
+            var shown = new HashSet<NetEntity>(contacts.Count);
+            foreach (var contact in contacts)
+            {
+                if (contact.Quality == KsPositionQuality.Exact)
+                    shown.Add(contact.Grid);
+            }
+
+            foreach (var (grid, offsets) in pool.LifeSigns)
+            {
+                // TargetNet, not GetNetEntity: the grid may have died since the sweep.
+                if (!pool.Contacts.TryGetValue(grid, out var record) || !shown.Contains(record.TargetNet))
+                    continue;
+
+                foreach (var offset in offsets)
+                    states.Add(new KsLifeSignState(record.TargetNet, offset));
+            }
+        }
+
+        foreach (var pos in pool.LifeSignFloaters.Values)
+            states.Add(new KsLifeSignState(null, pos));
+
+        return states.Count > 0 ? states : null;
     }
 
     /// <summary>

--- a/Content.Shared/_KS14/Sensors/KsSensorNavState.cs
+++ b/Content.Shared/_KS14/Sensors/KsSensorNavState.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._KS14.Sensors;
@@ -75,7 +76,21 @@ public sealed class KsSensorNavState
     ///         leak emitters the grid has not actually heard. Null when the log is empty.
     /// </summary>
     public List<KsEmissionLogEntry>? EmissionLog;
+
+    /// <summary>
+    ///     Life-sign blips from the grid's own IRSTs, strictly sweep-fresh: a track
+    ///         going ghost drops its crew dots the same push. Null when none.
+    /// </summary>
+    public List<KsLifeSignState>? LifeSigns;
 }
+
+/// <summary>
+///     One life-sign blip. <see cref="Grid"/> set: a centre-of-mass-relative offset
+///         in that contact's local frame (rides the dead-reckoned hull); null: a
+///         world position. Never carries identity.
+/// </summary>
+[Serializable, NetSerializable]
+public readonly record struct KsLifeSignState(NetEntity? Grid, Vector2 Position);
 
 [Serializable, NetSerializable]
 public enum KsEmissionLogKind : byte

--- a/Content.Shared/_KS14/Sensors/Prototypes/KsSensorHudPrototype.cs
+++ b/Content.Shared/_KS14/Sensors/Prototypes/KsSensorHudPrototype.cs
@@ -334,6 +334,10 @@ public sealed partial class KsSensorHudPrototype : IPrototype
     [DataField]
     public Color Interest = Color.DarkGoldenrod;
 
+    /// <summary>The IRST life-sign dot.</summary>
+    [DataField]
+    public Color LifeSign = Color.FromHex("#FFB347");
+
     /// <summary>Fill alpha of a filled coverage cone, further scaled by the emitting pulse.</summary>
     [DataField]
     public float ConeFillAlpha = 0.07f;

--- a/Content.Tests/Client/_KS14/Sensors/KsRegionDrawTest.cs
+++ b/Content.Tests/Client/_KS14/Sensors/KsRegionDrawTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Content.Client._KS14.Shuttles.UI;
@@ -35,9 +36,11 @@ public sealed class KsRegionDrawTest
         var gridToView = Matrix3x2.CreateTranslation(100f, 50f);
         var worldToView = Matrix3x2.CreateScale(2f, -2f) * Matrix3x2.CreateTranslation(999f, 999f);
 
-        var verts = KsRegionDraw.BuildVerts(region, gridToView, worldToView);
+        var verts = Array.Empty<Vector2>();
+        var count = KsRegionDraw.BuildVerts(region, gridToView, worldToView, ref verts);
 
         var apex = new Vector2(101f, 52f);
+        Assert.That(count, Is.EqualTo(2));
         Assert.That(verts[0], Is.EqualTo(apex));
         Assert.That(verts[1], Is.EqualTo(apex + new Vector2(20f, 0f)),
             "a world offset must scale/rotate with the view but never pick up its translation");
@@ -51,7 +54,8 @@ public sealed class KsRegionDrawTest
         var gridToView = Matrix3x2.CreateTranslation(100f, 50f);
         var worldToView = Matrix3x2.CreateScale(2f, -2f);
 
-        var verts = KsRegionDraw.BuildVerts(region, gridToView, worldToView);
+        var verts = Array.Empty<Vector2>();
+        KsRegionDraw.BuildVerts(region, gridToView, worldToView, ref verts);
 
         Assert.That(verts[1], Is.EqualTo(new Vector2(110f, 50f)));
     }

--- a/Resources/Prototypes/_KS14/sensor_hud.yml
+++ b/Resources/Prototypes/_KS14/sensor_hud.yml
@@ -40,6 +40,7 @@
   selfPosition: "#00FF00"
   offGrid: "#00FFFF"
   interest: "#B8860B"
+  lifeSign: "#FFB347"
 
   # Coverage cone. Alphas are scaled by the emitting pulse (radar/jammer) or by 1
   # for a passive fan (visual/IRST), which holds steady.


### PR DESCRIPTION
## What was changed
- IRST sensors now show life-sign blips: a small dot per live creature aboard any hull the IRST currently tracks, plus free-floaters in the open. Positions only go over the wire, never identity; dots vanish the moment the track is lost. No datalink relay, no memory.
- Performance pass over the sensor suite and console UI:
  - ESM roster and selected panel no longer rebuild localized strings and relayout labels every frame.
  - Thermal/RCS signature cache is incremental per grid instead of re-walking every wall in the game twice a second.
  - Coverage-fan raycasts terminate at the first blocker instead of walking the full range corridor.
  - A single datalink pair no longer forces a full state push to every open console every tick.
  - Radar readout strings memoized per push; life-sign dots and coverage fans batched/de-allocated.
- Fixed radar interest markers: the cull compared pixels to world metres, hiding all interests on maps far from the origin (also fixed in the vanilla control).

## Why


## Test plan
- `dotnet test Content.IntegrationTests --filter "FullyQualifiedName~Tests._KS14.Sensors"`
- `dotnet test Content.Tests --filter "FullyQualifiedName~_KS14.Sensors"`
- Ingame: open a sensor console near a crewed tracked grid, expect amber dots riding the hull; kill the track (cold hull, out of range) and the dots drop the same push. Watch frame time with the ESM tab open and a large roster.

## Media

## Requirements
- [x] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] Design doc

## Breaking changes
- `KsRegionDraw.BuildVerts` now fills a caller-owned buffer and returns a count.
- `KsSensorNavState` gained `LifeSigns`; client and server must be on the same build.
- Engine note: batched `DrawPrimitives` spans must stay chunked (stackalloc per vertex, ~64k batch cap) and component lifecycle events allow one handler per component type game-wide.

**Changelog**
:cl:
- add: IRST sensors now show life-sign blips for live creatures aboard tracked hulls and adrift in space.
- fix: Fixed FPS drops while using the shuttle sensor console.
- fix: Radar interest markers now show on maps far from the origin.
