### PR TITLE
docs: add sensor, datalink and shuttle console guidebook entries

### DIFF
--- a/Content.Shared/_KS14/Sensors/KsDatalinkComponents.cs
+++ b/Content.Shared/_KS14/Sensors/KsDatalinkComponents.cs
@@ -1,4 +1,5 @@
 using Content.Shared._KS14.Sensors.Prototypes;
+using Content.Shared.Guidebook;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._KS14.Sensors;
@@ -36,6 +37,7 @@ public sealed partial class KsDatalinkTransmitterComponent : Component
     /// <summary>Hard range cap at 100% power. Ignored entirely when <see cref="UnlimitedRange"/> is set.</summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
+    [GuidebookData]
     public float MaxRange = 768f;
 
     /// <summary>
@@ -91,6 +93,7 @@ public sealed partial class KsDatalinkTransmitterComponent : Component
     ///         loop/echo insurance for relay chains.
     /// </summary>
     [DataField]
+    [GuidebookData]
     public int HopLimit = 4;
 
     /// <summary>

--- a/Content.Shared/_KS14/Sensors/KsJammerComponent.cs
+++ b/Content.Shared/_KS14/Sensors/KsJammerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared._KS14.Sensors.Prototypes;
+using Content.Shared.Guidebook;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._KS14.Sensors;
@@ -35,6 +36,7 @@ public sealed partial class KsJammerComponent : Component
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
+    [GuidebookData]
     public float JammingPower = 192f;
 
     /// <summary>
@@ -43,6 +45,7 @@ public sealed partial class KsJammerComponent : Component
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
+    [GuidebookData]
     public float HalfAngle = 45f;
 
     /// <summary>

--- a/Content.Shared/_KS14/Sensors/KsSensorComponent.cs
+++ b/Content.Shared/_KS14/Sensors/KsSensorComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared._KS14.Sensors.Prototypes;
+using Content.Shared.Guidebook;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._KS14.Sensors;
@@ -22,6 +23,7 @@ public sealed partial class KsSensorComponent : Component
     /// <summary>Maximum detection range in meters/tiles.</summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
+    [GuidebookData]
     public float MaxRange = 160f;
 
     /// <summary>
@@ -221,6 +223,7 @@ public sealed partial class KsRadarComponent : Component
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
+    [GuidebookData]
     public float ConeRangeFactor = 2f;
 
     /// <summary>
@@ -233,6 +236,7 @@ public sealed partial class KsRadarComponent : Component
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
+    [GuidebookData]
     public float BurnThroughFactor = 0.5f;
 
     /// <summary>
@@ -291,6 +295,7 @@ public sealed partial class KsElintComponent : Component
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
+    [GuidebookData]
     public float AnalysisTime = 30f;
 
     /// <summary>

--- a/Content.Shared/_KS14/Sensors/KsSensorNavState.cs
+++ b/Content.Shared/_KS14/Sensors/KsSensorNavState.cs
@@ -66,7 +66,7 @@ public sealed class KsSensorNavState
 
     /// <summary>
     ///     Gates the ESM tab's warning side (threat channels, posture, the tab-alert
-    ///         flash), which degrades to a "NO RWR RECEIVER" chip without a receiver.
+    ///         flash), which degrades to a "NO RADAR WARNING RECEIVER" chip without a receiver.
     /// </summary>
     public bool HasRwr;
 

--- a/Resources/Locale/en-US/_KS14/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_KS14/guidebook/guides.ftl
@@ -1,3 +1,7 @@
 
 guide-entry-surgery = Surgery
 guide-entry-arcflash = Arc Flash
+guide-entry-sensors = Sensors
+guide-entry-sensor-arrays = Sensor Arrays
+guide-entry-datalink = Datalink
+guide-entry-shuttle-console = Shuttle Console

--- a/Resources/Locale/en-US/_KS14/sensors.ftl
+++ b/Resources/Locale/en-US/_KS14/sensors.ftl
@@ -136,7 +136,7 @@ ks-esm-panel-threat = WARNING RECEIVER
 ks-esm-panel-selected = SIGNAL ANALYSIS
 ks-esm-panel-log = EMISSION LOG
 
-ks-esm-chip-no-rwr = NO RWR RECEIVER
+ks-esm-chip-no-rwr = NO RADAR WARNING RECEIVER
 ks-esm-chip-no-elint = NO ELINT ARRAY
 ks-esm-chip-elint-deaf = ELINT DEAF - OWN EMISSIONS
 ks-esm-roster-offline = NO ESM RECEIVERS

--- a/Resources/Prototypes/Guidebook/engineering.yml
+++ b/Resources/Prototypes/Guidebook/engineering.yml
@@ -8,6 +8,7 @@
   - Atmospherics
   - Plumbing # Starlight
   - ShuttleCraft
+  - Sensors # KS14
   - Networking
 
 - type: guideEntry

--- a/Resources/Prototypes/_KS14/Guidebook/engineering.yml
+++ b/Resources/Prototypes/_KS14/Guidebook/engineering.yml
@@ -2,3 +2,27 @@
   id: ArcFlash
   name: guide-entry-arcflash
   text: "/ServerInfo/_KS14/Guidebook/Engineering/ArcFlash.xml"
+
+- type: guideEntry # KS14
+  id: Sensors
+  name: guide-entry-sensors
+  text: "/ServerInfo/_KS14/Guidebook/Engineering/Sensors.xml"
+  children:
+  - SensorArrays
+  - Datalink
+  - ShuttleConsole
+
+- type: guideEntry # KS14
+  id: SensorArrays
+  name: guide-entry-sensor-arrays
+  text: "/ServerInfo/_KS14/Guidebook/Engineering/SensorArrays.xml"
+
+- type: guideEntry # KS14
+  id: Datalink
+  name: guide-entry-datalink
+  text: "/ServerInfo/_KS14/Guidebook/Engineering/Datalink.xml"
+
+- type: guideEntry # KS14
+  id: ShuttleConsole
+  name: guide-entry-shuttle-console
+  text: "/ServerInfo/_KS14/Guidebook/Engineering/ShuttleConsole.xml"

--- a/Resources/ServerInfo/_KS14/Guidebook/Engineering/Datalink.xml
+++ b/Resources/ServerInfo/_KS14/Guidebook/Engineering/Datalink.xml
@@ -1,0 +1,41 @@
+<Document>
+  # Datalink
+  Every console on your ship already shares your ship's sensor picture. You do not have to wire anything up for that; if an array on the hull finds something, every console aboard knows about it.
+
+  The datalink is how that picture leaves the ship. It is two machines, and they work like a pair of walkie-talkies.
+
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineDatalinkTransmitter"/>
+    <GuideEntityEmbed Entity="KsMachineDatalinkReceiver"/>
+  </Box>
+
+  ## Transmitter
+  The transmitter broadcasts everything your ship knows, live tracks and old ghosts alike, on a frequency of your choosing. Click it to open the tuner.
+
+  There are two settings. The [bold]frequency[/bold] is a channel number, and both ends of a link have to agree on it. The [bold]transmit power[/bold] slider trades reach against your APC: at full power it carries [color=orange][protodata="KsMachineDatalinkTransmitter" comp="KsDatalinkTransmitter" member="MaxRange" format="N0"/] metres[/color] and eats a serious amount of electricity, and at low power it is cheap and quiet. The window shows the effective range as you drag it.
+
+  A transmitter always includes a report of your own ship in the broadcast, with its name, position, outline and stats. Anyone listening on your channel sees you, whether or not your sensors ever found them.
+
+  ## Receiver
+  The receiver is passive. Tune it to a frequency and everything it hears gets folded into your ship's picture as if your own arrays had found it. Its window shows how many links it is currently hearing, which is a quick way to check that a channel is live.
+
+  A receiver on its own is a perfectly good fit for a ship that would rather stay quiet. You get the whole network's eyes and give away nothing.
+
+  ## Nobody is encrypting anything
+  There is no key, no handshake and no friend-or-foe check. A frequency is just a number, and the tuner does not have all that many of them.
+
+  Anyone who guesses your channel hears your entire picture, learns where your ship is, and learns where everything you have found is. It also means you can do exactly that to somebody else. If you want a channel to stay yours, agree on it in person and change it when a ship goes missing.
+
+  Learning someone's frequency takes physical access to their machine, so a captured or abandoned hull is worth examining before you scuttle it.
+
+  ## What a network buys you
+  Contacts are passed on down a chain of ships, up to [color=orange][protodata="KsMachineDatalinkTransmitter" comp="KsDatalinkTransmitter" member="HopLimit" format="N0"/] relays[/color] deep, and a contact's readout tells you how many hops it travelled. A picture from the far end of a chain is still a picture, but whoever found it may have moved on since.
+
+  Two things are worth building a network for on their own:
+
+  - [bold]Jamming does not stop it.[/bold] A jammer blinds radar. It does nothing to a cable of ones and zeroes coming from an ally who is standing outside the wedge. If your radar goes dark, an ally's picture is your picture.
+  - [bold]Bearings cross into fixes.[/bold] Two ships on the same network, both hearing the same emitter from sufficiently different angles, turn two useless directions into one exact position. That is the whole reason to fly ELINT in pairs.
+
+  ## Public beacons
+  Stations and other landmarks carry beacons that announce themselves on every channel across the whole sector. You do not have to tune to them and you cannot silence them; a receiver alone is enough to always know where home is.
+</Document>

--- a/Resources/ServerInfo/_KS14/Guidebook/Engineering/SensorArrays.xml
+++ b/Resources/ServerInfo/_KS14/Guidebook/Engineering/SensorArrays.xml
@@ -1,0 +1,82 @@
+<Document>
+  # Sensor Arrays
+  Arrays are ordinary machines. Print the board at a circuit imprinter, build a machine frame, feed it the parts it asks for and slot the board in.
+
+  <Box>
+    <GuideEntityEmbed Entity="CircuitImprinter"/>
+    <GuideEntityEmbed Entity="SheetSteel" Caption=""/>
+    <GuideEntityEmbed Entity="SheetGlass" Caption=""/>
+    <GuideEntityEmbed Entity="MicroManipulatorStockPart" Caption=""/>
+  </Box>
+
+  ## Mounting and power
+  An array only works while it is anchored and powered, and most of them are hungry. Wire them properly, or the first time you switch everything on you will brown out the ship.
+
+  Passive arrays can sit anywhere inside the hull. The radar, the warning receiver and the jammer need a real hull aperture, which means the tile they are anchored on must have at least one open, tile-less neighbour.
+
+  Examine an array to find out what it thinks of its situation. It will tell you whether it is tracking normally, switched off, unpowered, or unable to see space.
+
+  ## Optical search array
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineVisualSearch"/>
+  </Box>
+  Short ranged and completely honest. It looks at space and picks out hulls, out to [color=orange][protodata="KsMachineVisualSearch" comp="KsSensor" member="MaxRange" format="N0"/] metres[/color].
+
+  Because it looks, it can be blocked. Your own hull, another ship or a chunk of terrain in the way all cast a shadow, and the console draws its coverage so you can see the gaps.
+
+  It is the only array that reads a ship's name, and it hands you SIZE, MASS and TOP SPEED. If you build one array, build this one.
+
+  ## IRST array
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineIrst"/>
+  </Box>
+  Infrared search and track. It hunts the heat bleeding off a hull, and it reaches [color=orange][protodata="KsMachineIrst" comp="KsSensor" member="MaxRange" format="N0"/] metres[/color], far past the naked eye.
+
+  What it reads is a ship's SIGNATURE, which comes from exposed exterior hull. A big ship with a lot of outside walls glows. A small one, or one built to run cold, gets close before anything shows up.
+
+  Like the optical array it is passive, so nobody can tell you are using it. It is also blocked by anything solid in the way.
+
+  ## Radar array
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineRadar"/>
+  </Box>
+  Active radar. It floods space with pulses and reads the echoes, out to [color=orange][protodata="KsMachineRadar" comp="KsSensor" member="MaxRange" format="N0"/] metres[/color], in the dark and through the cold. Nothing else you can build sees that far.
+
+  The catch is that a radar is a torch in a dark room. Its beam carries [color=orange][protodata="KsMachineRadar" comp="KsRadar" member="ConeRangeFactor" format="0.#"/] times[/color] as far as it can actually resolve, and every ELINT array inside that reach hears you. A jammer can blind it, too.
+
+  Radar is therefore a switch, not a fitting. Turn it on from the shuttle console when you need to see, and turn it off when you would rather not be seen. It reads RCS, which is how well a hull reflects, and is unrelated to how hot the hull runs.
+
+  ## ELINT array
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineElint"/>
+  </Box>
+  Electronic intelligence. It emits nothing whatsoever. It simply listens for other people's radars and jammers and tells you which direction they are coming from.
+
+  It gives you a bearing, not a position, and it reads back the RADAR RANGE of what it hears, so you learn how far the other ship can see before it gets to use that against you.
+
+  There are two ways to turn a bearing into a real fix. Have an ally on your datalink listen to the same emitter from a different angle and let the bearings cross, or select the emitter on the console and run a signal analysis, which takes [color=orange][protodata="KsMachineElint" comp="KsElint" member="AnalysisTime" format="N0"/] seconds[/color] of uninterrupted listening and peels out the emitter's size, mass and top speed along the way.
+
+  One warning: an ELINT array goes deaf while your own ship is emitting. If your radar or your jammer is on, your ELINT is useless.
+
+  ## Radar warning receiver
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineRwr"/>
+  </Box>
+  The cheap one, and the one nobody should fly without. It does not search for anything. It only reports emissions that are actually falling on your hull: a radar beam painting you, a jam wedge washing over you.
+
+  Its bearings are crude and it will never triangulate. What it gives you is the one thing that matters in the moment, which is that somebody out there is pointing something at you, and roughly where they are standing.
+
+  Unlike the ELINT array it keeps warning you while your own radar is running.
+
+  ## Jammer array
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineJammer"/>
+  </Box>
+  Not a sensor. It detects nothing and produces no contacts. It floods a wedge in front of itself with noise and blinds the radar of every ship caught in the wedge.
+
+  The wedge points wherever the machine is facing, so rotate the machine to aim it. It covers [color=orange][protodata="KsMachineJammer" comp="KsJammer" member="HalfAngle" format="N0"/] degrees[/color] either side of that facing, reaches [color=orange][protodata="KsMachineJammer" comp="KsJammer" member="JammingPower" format="N0"/] metres[/color], and does not care about walls or terrain. It has no rear coverage at all, which is the only reason it does not blind your own fleet outright.
+
+  It is not a magic shield. A jammed ship that closes to within [color=orange][protodata="KsMachineRadar" comp="KsRadar" member="BurnThroughFactor" format="P0"/][/color] of your reach burns through the noise and sees normally again. It can also just borrow an unjammed ally's picture over the datalink. And while it does not show up as a contact, every ELINT array in the sector hears it plainly and knows exactly what it is listening to.
+
+  It also blinds friendly radars, and it is by far the biggest power draw on this list. Aim it, and switch it off when you are done.
+</Document>

--- a/Resources/ServerInfo/_KS14/Guidebook/Engineering/Sensors.xml
+++ b/Resources/ServerInfo/_KS14/Guidebook/Engineering/Sensors.xml
@@ -1,0 +1,52 @@
+<Document>
+  # Sensors
+  Your ship does not see another ship because it is nearby. It sees it because a machine on your hull found it and reported it to your console.
+
+  <Box>
+    <GuideEntityEmbed Entity="KsMachineIrst"/>
+    <GuideEntityEmbed Entity="KsMachineDatalinkTransmitter"/>
+    <GuideEntityEmbed Entity="KsComputerShuttle"/>
+  </Box>
+
+  Three things do the work, and each has its own page:
+  - [textlink="Sensor arrays" link="SensorArrays"] search space and produce contacts.
+  - The [textlink="datalink" link="Datalink"] trades contacts with other ships.
+  - The [textlink="shuttle console" link="ShuttleConsole"] draws everything your ship knows.
+
+  A ship with no arrays and no datalink sees nothing at all, and an empty screen is exactly what that looks like. It is not a broken console. It is a blind ship.
+
+  ## Contacts
+  A contact is one thing your ship has found. Your own ship always sits in the middle of the plot; everything else is drawn around it.
+
+  Contacts come in two states. A [bold]live[/bold] contact is being tracked right now and draws brightly. When the track is lost the contact does not vanish, it dims into a [bold]memory ghost[/bold] and stays at the last known spot.
+
+  Ghosts never expire on their own. They are cleared when one of your arrays gets a clear look at that spot and confirms it is empty. Anything that moves therefore leaves stale ghosts behind it, so treat a dim contact as a rumour and a bright one as a target.
+
+  Small drifting junk is filtered out, so an empty plot really is empty of anything worth worrying about.
+
+  ## Reading the colours
+  A contact is coloured by the kind of array holding the track. If several arrays see it at once, the more trustworthy one wins.
+
+  - [color=#C0C0C0]Silver[/color] is the optical array. It saw the hull with its own eyes.
+  - [color=#FF4040]Red[/color] is IRST. It found the heat coming off a hull.
+  - [color=#40C040]Green[/color] is radar. It bounced a pulse off something.
+  - [color=#FF9020]Orange[/color] is ELINT. It heard a radar emitting somewhere out there.
+  - [color=#C0A060]Tan[/color] is the warning receiver. Something is illuminating your ship right now.
+  - [color=#C050F0]Violet[/color] is a jammer that has been located.
+  - [color=#00FA9A]Spring green[/color] is a ship announcing itself over the datalink. That is almost always a friend.
+
+  ## Readouts
+  Each contact carries whatever your arrays managed to work out about it. Hover it on the plot for the full picture, or use the contact info button to keep the lines on screen.
+
+  Different arrays learn different things: SIZE, MASS and TOP SPEED come from the optical array, SIGNATURE from IRST, RCS from radar, RADAR RANGE from ELINT. The more kinds of array you run, the fuller the readout.
+
+  A readout line showing [bold]---[/bold] means nothing you own has resolved that value yet.
+
+  ## Bearings
+  Some contacts have no position at all. Listening equipment hears a direction, not a distance, so it draws a thin wedge pointing away from your ship instead of a marker sitting somewhere.
+
+  A bearing is still useful. Point the bow down it, or get a second ship on your datalink to listen from a different angle and let the two lines cross into a real fix.
+
+  ## Where to start
+  If you are fitting out a ship for the first time, build an [textlink="optical search array" link="SensorArrays"] and a warning receiver. The optical array tells you who is out there and the warning receiver tells you when somebody is looking at you. Everything else is refinement.
+</Document>

--- a/Resources/ServerInfo/_KS14/Guidebook/Engineering/ShuttleConsole.xml
+++ b/Resources/ServerInfo/_KS14/Guidebook/Engineering/ShuttleConsole.xml
@@ -1,0 +1,57 @@
+<Document>
+  # Shuttle Console
+  The shuttle console is where the sensor picture actually lives. It is still the thing you fly the ship with, but it now has four faces, listed across the top of the window as RADAR // MAP // ESM // DOCK.
+
+  <Box>
+    <GuideEntityEmbed Entity="KsComputerShuttle"/>
+    <GuideEntityEmbed Entity="KsComputerShuttleIdLocked"/>
+  </Box>
+
+  Two buttons sit in the corner of the window. [bold]POP[/bold] moves the whole suite into its own window so you can keep it open next to the game, and closing that window brings it back. [bold]X[/bold] closes the console. The console also remembers which face you left it on.
+
+  Along the top edge is a status strip that is readable from across the room:
+  - [bold]CON[/bold] is how many contacts your ship is holding.
+  - [bold]EMT[/bold] is how many emitters are being heard.
+  - [bold]RDR[/bold] and [bold]JAM[/bold] are your own radar and jammer. Three dashes mean you have not built one.
+  - [bold]! JAMMED ![/bold] means somebody is jamming you right now.
+
+  ## RADAR
+  The flying face. The plot in the middle is your ship and everything around it; the panels down the right side are the numbers.
+
+  [bold]SHIP[/bold] is your position, heading, velocity and turn rate. [bold]STATUS[/bold] is the short version of how much trouble you are in: posture (CALM, CAUTION or DANGER), how many things are illuminating you, how many contacts you hold and how many emitters you hear.
+
+  [bold]EMISSIONS[/bold] holds the two switches that give you away. The radar button toggles between quiet and emitting, and only appears if your ship has a radar. The jammer button does the same for a jammer. You cannot run both at once; switching one on silences the other. Neither is a fitting you can forget about, both are decisions.
+
+  [bold]DISPLAY[/bold] is presentation only and changes nothing about what your ship can actually see:
+  - Docking ports on or off, as before.
+  - One cone button per array type. Each cycles OFF, OUTLINE and FILLED, and shows you where that kind of array is actually looking. Use it to find the blind spot your own hull is making.
+  - Contact info cycles OFF, BASIC and FULL. BASIC keeps names and the most important line; FULL adds coordinates, range, age and every readout your arrays resolved. Turn it down when the plot gets crowded.
+
+  The cones on this face are your own ship's. An enemy's coverage is never drawn for you, and yours is never drawn for them.
+
+  ## MAP
+  The sector chart and the FTL controls. It works the way it always has, with one addition: the [bold]SENSORS[/bold] button overlays the coverage of your whole datalink network, allied arrays included, along with its live contacts.
+
+  Allies stay charted whether the overlay is on or off, so you can turn it off for a clean jump plan without losing track of your own fleet.
+
+  ## ESM
+  Electronic support. This is the listening face, and it is fed by the ELINT array and the warning receiver. If you own neither, the screen says so and does nothing useful.
+
+  [bold]BEARING PLOT[/bold] is drawn bow-up, so a strobe pointing at the top of the dial is a strobe dead ahead. Turn the ship and watch the lines swing.
+
+  [bold]EMITTERS[/bold] is the roster of everything you have ever heard. Each gets a designation like E-001 which is shared across your whole datalink network, so you and your allies are talking about the same contact. LIVE means it is emitting right now; MEM means it has gone quiet.
+
+  [bold]WARNING RECEIVER[/bold] is the panel that will keep you alive. It only lists emissions actually falling on your hull, grouped as SEARCH or JAM, with the posture on top. The ESM tab button itself flashes in the posture colour, so you get the warning even while you are looking at another face.
+
+  [bold]SIGNAL ANALYSIS[/bold] describes whichever emitter you have selected: its class, its band, how strong the signal is, whether the bearing is holding steady or drifting, and how long ago it was last heard. [bold]FOCUS[/bold] starts a patient analysis of it that peels out the ship's size, mass and top speed as it runs and, if the emitter keeps talking to the end, resolves it into an exact position. [bold]CEASE[/bold] stops. Focus is a commitment; you get one at a time.
+
+  [bold]EMISSION LOG[/bold] is the timestamped history of what appeared, what went quiet and when you were jammed. It is the honest record of an engagement, and worth reading after one.
+
+  ## DOCK
+  Unchanged in how it works, just rebuilt to match the rest of the suite. Pick a port, line up, dock.
+
+  ## When it all goes dark
+  If [bold]! JAMMED ![/bold] appears, your radar has stopped producing anything new. Contacts held by another array or arriving over the datalink carry on as normal, so the picture only really collapses if radar was all you had.
+
+  You have three answers. Close the distance until you burn through the noise, get out of the wedge, since a jammer has no rear coverage at all, or ask an ally outside it to feed you their picture over the [textlink="datalink" link="Datalink"].
+</Document>


### PR DESCRIPTION
## What was changed
- Added guidebook entries: Sensors, Sensor Arrays, Datalink, Shuttle Console
- Marked key sensor, datalink and jammer datafields with `GuidebookData` so values show ingame
- Shuttle console ESM chip now reads "NO RADAR WARNING RECEIVER"

## Why
Sensor and datalink mechanics had no ingame documentation.

## Test plan
Open the guidebook ingame, check the Engineering section for the four new entries, and confirm the ESM chip text on the shuttle console.

## Media
<img width="1460" height="932" alt="image" src="https://github.com/user-attachments/assets/395dc0fe-ab1d-4c37-a0f3-4d4563fe5622" />
<img width="1463" height="355" alt="image" src="https://github.com/user-attachments/assets/4f8d4979-b30a-48c4-a72d-7c6560c4aa66" />
<img width="1675" height="893" alt="image" src="https://github.com/user-attachments/assets/419e354b-1260-4f0f-801c-8bad73dc2ced" />
<img width="1691" height="905" alt="image" src="https://github.com/user-attachments/assets/c1a81392-7b4c-4ed0-bd10-a82a18fb05c7" />
<img width="1456" height="337" alt="image" src="https://github.com/user-attachments/assets/2c6ba3dc-a577-4e2a-94de-bae0653515f4" />
<img width="1704" height="1018" alt="image" src="https://github.com/user-attachments/assets/4d16a5e2-dd20-4a8b-b141-063f9c84dd46" />

## Requirements
- [X] Tested, works.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] Design doc

## Breaking changes
None

**Changelog**
:cl:
- add: Added guidebook entries for sensors, sensor arrays, datalink and the shuttle console
