### PR TITLE
Nonstatic storage, also fix cvar configpreset not replicating to client

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -165,7 +165,15 @@ public sealed partial class StorageUIController : UIController, IOnSystemChanged
             {
                 window.Open(pos);
             }
-            // Open at the default position.
+            // KS14 Start: fixing non-static storage ui to open at same place as static
+            // Open at the same default position that a static storage window would use:
+            // centered horizontally above the hotbar.
+            else if (GetStaticDefaultPosition(window) is { } defaultPos)
+            {
+                window.Open(defaultPos);
+            }
+            // Fall back to the old default position if the hotbar isn't available.
+            // KS14 End
             else
             {
                 window.OpenCenteredLeft();
@@ -175,6 +183,25 @@ public sealed partial class StorageUIController : UIController, IOnSystemChanged
         _ui.RegisterControl(sBui, window);
         return window;
     }
+
+    // KS14 Start: fixing non-static storage ui to open at same place as static
+    /// Computes the top-left position for a non-static window so that it appears
+    /// centered above the hotbar, matching where a static storage window shows up.
+    private Vector2? GetStaticDefaultPosition(StorageWindow window)
+    {
+        var hotbar = UIManager.GetActiveUIWidgetOrNull<HotbarGui>();
+        if (hotbar == null)
+            return null;
+
+        window.Measure(Vector2Helpers.Infinity);
+
+        const float margin = 10f;
+        var centerX = hotbar.GlobalPosition.X + hotbar.Width / 2f;
+        var topY = hotbar.GlobalPosition.Y;
+
+        return new Vector2(centerX - window.DesiredSize.X / 2f, topY - window.DesiredSize.Y - margin);
+    }
+    // KS14 End
 
     public void OnSystemLoaded(StorageSystem system)
     {

--- a/Content.Client/_KS14/Entry/KsEntryPoint.cs
+++ b/Content.Client/_KS14/Entry/KsEntryPoint.cs
@@ -17,7 +17,7 @@ internal sealed partial class KsEntryPoint : GameClient
     [Dependency] private IConfigurationManager _configurationManager = default!;
     [Dependency] private IResourceManager _resourceManager = default!;
     [Dependency] private IBaseClient _baseClient = default!;
-    [Dependency] private ISawmill _sawmill = default!;
+    [Dependency] private ILogManager _logManager = default!;
     [Dependency] private SystemCollectionHookManager _systemCollectionHookManager = default!;
     [Dependency] private KsAdminMusicManager _adminMusicManager = default!;
 
@@ -41,7 +41,7 @@ internal sealed partial class KsEntryPoint : GameClient
     // LCDC FUTURE: Remove this if configpresets gets to client on upstream
     private void LoadConfigPresets()
     {
-        // KS14: Changed logic to always include `KS14/ks14_base`
+        var sawmill = _logManager.GetSawmill("configpreset");
         var presets = _configurationManager.GetCVar(CCVars.ConfigPresets).Split(',').ToList();
         presets.Add("KS14/ks14_base");
 
@@ -53,12 +53,12 @@ internal sealed partial class KsEntryPoint : GameClient
             var path = $"{ConfigPresetsDir}{preset}.toml";
             if (!_resourceManager.TryContentFileRead(path, out var file))
             {
-                _sawmill.Error("Unable to load config preset {Preset}!", path);
+                sawmill.Error("Unable to load config preset {Preset}!", path);
                 continue;
             }
 
             _configurationManager.LoadDefaultsFromTomlStream(file);
-            _sawmill.Info("Loaded config preset: {Preset}", path);
+            sawmill.Info("Loaded config preset: {Preset}", path);
         }
     }
 

--- a/Content.Client/_KS14/Entry/KsEntryPoint.cs
+++ b/Content.Client/_KS14/Entry/KsEntryPoint.cs
@@ -1,14 +1,23 @@
+using System.Linq;
 using Content.Client._KS14.AdminMusic;
 using Content.Client._KS14.IoC;
 using Content.Shared._KS14.IoC;
+using Content.Shared.CCVar;
 using Robust.Client;
+using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 
 namespace Content.Client._KS14.Entry;
 
 internal sealed partial class KsEntryPoint : GameClient
 {
+    internal const string ConfigPresetsDir = "/ConfigPresets/";
+    private const string ConfigPresetsDirBuild = $"{ConfigPresetsDir}Build/";
+
+    [Dependency] private IConfigurationManager _configurationManager = default!;
+    [Dependency] private IResourceManager _resourceManager = default!;
     [Dependency] private IBaseClient _baseClient = default!;
+    [Dependency] private ISawmill _sawmill = default!;
     [Dependency] private SystemCollectionHookManager _systemCollectionHookManager = default!;
     [Dependency] private KsAdminMusicManager _adminMusicManager = default!;
 
@@ -24,7 +33,33 @@ internal sealed partial class KsEntryPoint : GameClient
         Dependencies.BuildGraph();
         Dependencies.InjectDependencies(this);
 
+        LoadConfigPresets();
+
         _adminMusicManager.Initialise();
+    }
+
+    // LCDC FUTURE: Remove this if configpresets gets to client on upstream
+    private void LoadConfigPresets()
+    {
+        // KS14: Changed logic to always include `KS14/ks14_base`
+        var presets = _configurationManager.GetCVar(CCVars.ConfigPresets).Split(',').ToList();
+        presets.Add("KS14/ks14_base");
+
+        foreach (var preset in presets)
+        {
+            if (preset.IsWhiteSpace())
+                continue;
+
+            var path = $"{ConfigPresetsDir}{preset}.toml";
+            if (!_resourceManager.TryContentFileRead(path, out var file))
+            {
+                _sawmill.Error("Unable to load config preset {Preset}!", path);
+                continue;
+            }
+
+            _configurationManager.LoadDefaultsFromTomlStream(file);
+            _sawmill.Info("Loaded config preset: {Preset}", path);
+        }
     }
 
     public override void PostInit()

--- a/Content.IntegrationTests/PoolManager.Cvars.cs
+++ b/Content.IntegrationTests/PoolManager.Cvars.cs
@@ -34,5 +34,6 @@ public static partial class PoolManager
         (CCVars.InteractionRateLimitCount.Name, "9999999"),
         (CCVars.InteractionRateLimitPeriod.Name, "0.1"),
         (CCVars.MovementMobPushing.Name, "false"),
+        (CCVars.StorageLimit.Name, "1") /* KS14 */,
     };
 }

--- a/Content.Packaging/ClientPackaging.cs
+++ b/Content.Packaging/ClientPackaging.cs
@@ -88,11 +88,17 @@ public static class ClientPackaging
                 "Content.Shared.Database" },
             cancel: cancel);
 
-        await RobustClientPackaging.WriteClientResources(
-            contentDir,
-            inputPass,
-            SharedPackaging.AdditionalIgnoredResources,
-            cancel);
+        // KS14 Start: proper packaging while not ignoring configpresets
+        var ignoreSet = RobustClientPackaging.ClientIgnoredResources
+            .Union(RobustSharedPackaging.SharedIgnoredResources)
+            .Union(SharedPackaging.AdditionalIgnoredResources)
+            .ToHashSet();
+
+        // dont ignore ConfigPresets ffs BROOOOOO
+        ignoreSet.Remove("ConfigPresets");
+
+        await RobustSharedPackaging.DoResourceCopy(Path.Combine(contentDir, "Resources"), inputPass, ignoreSet, cancel: cancel);
+        // KS14 End
 
         inputPass.InjectFinished();
     }

--- a/Content.Shared/CCVar/CCVars.Config.cs
+++ b/Content.Shared/CCVar/CCVars.Config.cs
@@ -16,7 +16,7 @@ public sealed partial class CCVars
     ///     Only the file name (without extension) must be given for this variable.
     /// </remarks>
     public static readonly CVarDef<string> ConfigPresets =
-        CVarDef.Create("config.presets", "", CVar.SERVERONLY);
+        CVarDef.Create("config.presets", "", CVar.REPLICATED | CVar.SERVER /* KS14: SERVERONLY -> REPLICATED | SERVER */);
 
     /// <summary>
     ///     Whether to load the preset development CVars.

--- a/Resources/ConfigPresets/KS14/ks14_base.toml
+++ b/Resources/ConfigPresets/KS14/ks14_base.toml
@@ -32,3 +32,9 @@ penalty_seconds = 180
 [ghost]
 # if in crit, do you immediately die when ghosting?
 kill_crit = true
+
+[control]
+# let storage ui be moved
+static_storage_ui = false
+# up to 2 storage uis open at once
+storage_limit = 2

--- a/Resources/ConfigPresets/KS14/ks14_base.toml
+++ b/Resources/ConfigPresets/KS14/ks14_base.toml
@@ -34,7 +34,5 @@ penalty_seconds = 180
 kill_crit = true
 
 [control]
-# let storage ui be moved
-static_storage_ui = false
 # up to 2 storage uis open at once
 storage_limit = 2


### PR DESCRIPTION
## What was changed
made configpreset replicate to client, and now cvars are set according to it
also configured storage to be not static

**Changelog**
:cl:
- tweak: you can have up to two storage UIs open.
- fix: Fixed KS14 config preset not working on client.
