### PR TITLE
Empable turrets

### DIFF
--- a/Content.Server/NPC/HTN/HTNSystem.Klovn.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.Klovn.cs
@@ -1,0 +1,17 @@
+using Content.Shared._KS14.IoC;
+using Content.Server._KS14.NPC;
+
+namespace Content.Server.NPC.HTN;
+
+public sealed partial class HTNSystem
+{
+    [Dependency] private SystemCollectionHookManager _collectionHook = default!;
+
+    public bool AttemptWork(EntityUid uid)
+    {
+        var ev = new AttemptNpcWorkEvent();
+        RaiseLocalEvent(uid, ref ev);
+
+        return !ev.Cancelled;
+    }
+}

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -23,7 +23,6 @@ public sealed partial class HTNSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private NPCSystem _npc = default!;
     [Dependency] private NPCUtilitySystem _utility = default!;
-    [Dependency] private SystemCollectionHookManager _collectionHook = default!; // KS14: ANK
 
     private readonly JobQueue _planQueue = new(0.004);
 
@@ -205,6 +204,11 @@ public sealed partial class HTNSystem : EntitySystem
 
             if (!comp.Enabled)
                 continue;
+
+            // KS14 Start
+            if (!AttemptWork(uid))
+                continue;
+            // KS14 End
 
             if (comp.PlanningJob != null)
             {

--- a/Content.Server/_KS14/NPC/AttemptNpcWorkEvent.cs
+++ b/Content.Server/_KS14/NPC/AttemptNpcWorkEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server._KS14.NPC;
+
+/// <summary>
+///     Raised on an entity with an npc component to potentially
+///         cancel any planning.
+/// </summary>
+[ByRefEvent]
+public record struct AttemptNpcWorkEvent(bool Cancelled);

--- a/Content.Server/_KS14/NPC/Components/EmpAffectedNpcComponent.cs
+++ b/Content.Server/_KS14/NPC/Components/EmpAffectedNpcComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._KS14.NPC.Components;
+
+/// <summary>
+///     Added to NPCs that can be EMP-ed to have their AI (temporarily) disabled.
+/// </summary>
+[RegisterComponent]
+public sealed partial class EmpAffectedNpcComponent : Component;

--- a/Content.Server/_KS14/NPC/Systems/EmpAffectedNpcSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/EmpAffectedNpcSystem.cs
@@ -1,0 +1,39 @@
+using Content.Server._KS14.NPC.Components;
+using Content.Server.NPC.Systems;
+using Content.Shared.Emp;
+
+namespace Content.Server._KS14.NPC.Systems;
+
+public sealed partial class EmpAffectedNpcSystem : EntitySystem
+{
+    [Dependency] private NPCSystem _npcSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmpAffectedNpcComponent, AttemptNpcWorkEvent>(OnAttemptNpcWork);
+        SubscribeLocalEvent<EmpAffectedNpcComponent, EmpPulseEvent>(OnEmpPulse);
+        SubscribeLocalEvent<EmpAffectedNpcComponent, EmpDisabledRemovedEvent>(OnEmpDisabledRemoved);
+    }
+
+    private void OnAttemptNpcWork(Entity<EmpAffectedNpcComponent> entity, ref AttemptNpcWorkEvent args)
+    {
+        if (args.Cancelled ||
+            !HasComp<EmpDisabledComponent>(entity))
+            return;
+
+        args.Cancelled = true;
+    }
+
+    private void OnEmpPulse(Entity<EmpAffectedNpcComponent> entity, ref EmpPulseEvent args)
+    {
+        args.Affected = true;
+        _npcSystem.SleepNPC(entity.Owner);
+    }
+
+    private void OnEmpDisabledRemoved(Entity<EmpAffectedNpcComponent> entity, ref EmpDisabledRemovedEvent args)
+    {
+        _npcSystem.WakeNPC(entity.Owner);
+    }
+}

--- a/Content.Shared/Emp/SharedEmpSystem.Klovn.cs
+++ b/Content.Shared/Emp/SharedEmpSystem.Klovn.cs
@@ -1,0 +1,8 @@
+using Content.Shared._KS14.PredictedSpawning;
+
+namespace Content.Shared.Emp;
+
+public abstract partial class SharedEmpSystem
+{
+    [Dependency] private KsSharedPredictedSpawnSystem _ksPredictedSpawnSystem = default!;
+}

--- a/Content.Shared/Emp/SharedEmpSystem.cs
+++ b/Content.Shared/Emp/SharedEmpSystem.cs
@@ -51,9 +51,9 @@ public abstract partial class SharedEmpSystem : EntitySystem
         {
             TryEmpEffects(uid, energyConsumption, duration, user);
         }
-        // TODO: replace with PredictedSpawn once it works with animated sprites
-        if (_net.IsServer)
-            Spawn(EmpPulseEffectPrototype, mapCoordinates);
+
+        // KS14: use _ksPredictedSpawnSystem and make it predicted
+        _ksPredictedSpawnSystem.PredictedSpawn(EmpPulseEffectPrototype, mapCoordinates);
 
         var coordinates = _transform.ToCoordinates(mapCoordinates);
         _audio.PlayPredicted(EmpSound, coordinates, user);
@@ -76,9 +76,9 @@ public abstract partial class SharedEmpSystem : EntitySystem
         {
             TryEmpEffects(uid, energyConsumption, duration, user);
         }
-        // TODO: replace with PredictedSpawn once it works with animated sprites
-        if (_net.IsServer)
-            Spawn(EmpPulseEffectPrototype, coordinates);
+
+        // KS14: use _ksPredictedSpawnSystem and make it predicted
+        _ksPredictedSpawnSystem.PredictedSpawnAttachedTo(EmpPulseEffectPrototype, coordinates);
 
         if (predicted)
             _audio.PlayPredicted(EmpSound, coordinates, user);
@@ -124,9 +124,9 @@ public abstract partial class SharedEmpSystem : EntitySystem
         var ev = new EmpPulseEvent(energyConsumption * strMultiplier, false, false, duration * durMultiplier, user);
         RaiseLocalEvent(uid, ref ev);
 
-        // TODO: replace with PredictedSpawn once it works with animated sprites
-        if (ev.Affected && _net.IsServer)
-            Spawn(EmpDisabledEffectPrototype, Transform(uid).Coordinates);
+        // KS14: use _ksPredictedSpawnSystem and make it predicted
+        if (ev.Affected)
+            _ksPredictedSpawnSystem.PredictedSpawnAttachedTo(EmpPulseEffectPrototype, Transform(uid).Coordinates);
 
         if (!ev.Disabled)
             return ev.Affected;

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
@@ -69,6 +69,7 @@
         3.141
       SoundTargetInLOS: !type:SoundPathSpecifier
         path: /Audio/Effects/double_beep.ogg
+  - type: EmpAffectedNpc # KS14 addition
   - type: MouseRotator
     angleTolerance: 5
     rotationSpeed: 180


### PR DESCRIPTION
## What was changed
Z
also predicted emp vfx though emp grenades themselves mispredict (thanks wizden)

https://github.com/user-attachments/assets/422a5681-5979-424f-aa9d-eca7ffe3b61f

**Changelog**
:cl:
- add: Turrets can now be EMPed to be temporarily disabled.
