### PR TITLE
Rework how c-4 and such explosives are planted

### DIFF
--- a/Content.Shared/Sticky/Components/StickyComponent.Klovn.cs
+++ b/Content.Shared/Sticky/Components/StickyComponent.Klovn.cs
@@ -1,0 +1,13 @@
+﻿using System.Numerics;
+
+namespace Content.Shared.Sticky.Components;
+
+public sealed partial class StickyComponent
+{
+    /// <summary>
+    ///     The position offset applied to the entity after it is stuck.
+    ///         Is affected by rotation.
+    /// </summary>
+    [DataField]
+    public Vector2 StuckOffset = Vector2.Zero;
+}

--- a/Content.Shared/Sticky/Systems/StickySystem.Klovn.cs
+++ b/Content.Shared/Sticky/Systems/StickySystem.Klovn.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Sticky.Components;
+
+namespace Content.Shared.Sticky.Systems;
+
+public sealed partial class StickySystem
+{
+    [Dependency] private SharedTransformSystem _transformSystem = default!;
+
+    private void RotateAndMove(Entity<StickyComponent> stuckEntity, EntityUid userUid)
+    {
+        var stuckTransformComponent = Transform(stuckEntity);
+        var userTransformComponent = Transform(userUid);
+
+        _transformSystem.SetLocalRotation(
+            stuckEntity.Owner,
+            -(_transformSystem.GetWorldPosition(userTransformComponent) - _transformSystem.GetWorldPosition(stuckTransformComponent)).ToAngle().RoundToCardinalAngle(),
+            xform: stuckTransformComponent
+        );
+
+        _transformSystem.SetLocalPosition(stuckEntity.Owner, stuckTransformComponent.LocalRotation.RotateVec(stuckEntity.Comp.StuckOffset), xform: stuckTransformComponent);
+    }
+}

--- a/Content.Shared/Sticky/Systems/StickySystem.cs
+++ b/Content.Shared/Sticky/Systems/StickySystem.cs
@@ -162,6 +162,8 @@ public sealed partial class StickySystem : EntitySystem
         if (!_container.Insert(uid, container))
             return;
 
+        RotateAndMove(ent, user); // KS14
+
         // show message to user
         if (comp.StickPopupSuccess != null)
         {

--- a/Content.Shared/_KS14/Sticky/ComponentsOnStickComponent.cs
+++ b/Content.Shared/_KS14/Sticky/ComponentsOnStickComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class ComponentsOnStickComponent : Component
     public bool RequiresOccluder = true;
 
     [DataField(required: true), ViewVariables]
-    public ComponentRegistry Components;
+    public ComponentRegistry Components = default!;
 
     /// <summary>
     ///     Whether the components are already added

--- a/Content.Shared/_KS14/Sticky/ComponentsOnStickComponent.cs
+++ b/Content.Shared/_KS14/Sticky/ComponentsOnStickComponent.cs
@@ -1,0 +1,29 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._KS14.Sticky;
+
+/// <summary>
+///     Adds components to itself when sticking to something, and removes them when unsticking.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class ComponentsOnStickComponent : Component
+{
+    /// <summary>
+    ///     If the thing being stuck to must be an occluder
+    ///         for these comps to be added.
+    /// </summary>
+    [DataField, ViewVariables]
+    public bool RequiresOccluder = true;
+
+    [DataField(required: true), ViewVariables]
+    public ComponentRegistry Components;
+
+    /// <summary>
+    ///     Whether the components are already added
+    /// </summary>
+    [DataField, ViewVariables]
+    [AutoNetworkedField]
+    public bool ComponentsGotAdded = false;
+}

--- a/Content.Shared/_KS14/Sticky/ComponentsOnStickSystem.cs
+++ b/Content.Shared/_KS14/Sticky/ComponentsOnStickSystem.cs
@@ -1,0 +1,40 @@
+using Content.Shared.Sticky;
+
+namespace Content.Shared._KS14.Sticky;
+
+public sealed partial class WallmountOnStickSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ComponentsOnStickComponent, EntityStuckEvent>(OnStuck);
+        SubscribeLocalEvent<ComponentsOnStickComponent, EntityUnstuckEvent>(OnUnstuck);
+    }
+
+    private void OnStuck(Entity<ComponentsOnStickComponent> entity, ref EntityStuckEvent args)
+    {
+        if (entity.Comp.ComponentsGotAdded)
+            return;
+
+        if (entity.Comp.RequiresOccluder &&
+            !HasComp<OccluderComponent>(args.Target))
+            return;
+
+        EntityManager.AddComponents(entity.Owner, entity.Comp.Components);
+
+        entity.Comp.ComponentsGotAdded = true;
+        Dirty(entity);
+    }
+
+    private void OnUnstuck(Entity<ComponentsOnStickComponent> entity, ref EntityUnstuckEvent args)
+    {
+        if (!entity.Comp.ComponentsGotAdded)
+            return;
+
+        EntityManager.RemoveComponents(args.Target, entity.Comp.Components);
+
+        entity.Comp.ComponentsGotAdded = false;
+        Dirty(entity);
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -16,6 +16,14 @@
       components:
       - Item
       - Spectral # special case for the rev since it can go incorporeal and ghost bomb you. Also, Idk, its like a ghost or something no touchy.
+    stuckOffset: 0,-0.25 # KS14
+  # KS14 Start
+  - type: ComponentsOnStick
+    requireOccluder: true
+    components:
+    - type: WallMount
+      arc: 80
+  # KS14 End
   - type: Damageable
   - type: Injurable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -19,7 +19,7 @@
     stuckOffset: 0,-0.25 # KS14
   # KS14 Start
   - type: ComponentsOnStick
-    requireOccluder: true
+    requiresOccluder: true
     components:
     - type: WallMount
       arc: 80


### PR DESCRIPTION
## What was changed
https://github.com/user-attachments/assets/e22340a0-1fc5-4cbd-8373-3f0325e29d60

**Changelog**
:cl:
- tweak: C-4, seismic charges, etc. now become wallmounts when planted and aren't visible from the side opposite from which they were planted on.