### PR TITLE
CampingMarker Emancipation Proclamation

### DIFF
--- a/Content.Client/_KS14/NPC/TacticalPositionDebugOverlay.cs
+++ b/Content.Client/_KS14/NPC/TacticalPositionDebugOverlay.cs
@@ -1,0 +1,80 @@
+using Content.Shared._KS14.NPC;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Maths;
+
+namespace Content.Client._KS14.NPC;
+
+/// <summary>
+/// Draws the most recent tactical position debug frame per NPC: every scored candidate (colored red-to-green
+/// by score), the chosen candidate (highlighted), and live claim-table entries (clearance-radius circles).
+/// </summary>
+public sealed class TacticalPositionDebugOverlay : Overlay
+{
+    private readonly TacticalPositionDebugSystem _system;
+    private readonly IEntityManager _entityManager;
+    private readonly SharedTransformSystem _transformSystem;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    private const float CandidateRadius = 0.12f;
+    private const float ChosenRadius = 0.2f;
+
+    public TacticalPositionDebugOverlay(TacticalPositionDebugSystem system, IEntityManager entityManager, IEyeManager eyeManager)
+    {
+        _system = system;
+        _entityManager = entityManager;
+        _eyeManager = eyeManager;
+        _transformSystem = entityManager.System<SharedTransformSystem>();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var worldHandle = args.WorldHandle;
+
+        foreach (var (_, frame) in _system.Frames)
+        {
+            var data = frame.Data;
+            var maxScore = 0.0001f;
+
+            foreach (var candidate in data.Candidates)
+            {
+                maxScore = MathF.Max(maxScore, candidate.Score);
+            }
+
+            foreach (var claim in data.Claims)
+            {
+                var claimCoordinates = _entityManager.GetCoordinates(claim.Coordinates);
+                var claimMapPosition = _transformSystem.ToMapCoordinates(claimCoordinates);
+
+                if (claimMapPosition.MapId != args.MapId)
+                    continue;
+
+                worldHandle.DrawCircle(claimMapPosition.Position, claim.ClearanceRadius, Color.Orange.WithAlpha(0.5f), false);
+            }
+
+            foreach (var candidate in data.Candidates)
+            {
+                var candidateCoordinates = _entityManager.GetCoordinates(candidate.Coordinates);
+                var candidateMapPosition = _transformSystem.ToMapCoordinates(candidateCoordinates);
+
+                if (candidateMapPosition.MapId != args.MapId)
+                    continue;
+
+                var color = Color.InterpolateBetween(Color.Red, Color.Lime, candidate.Score / maxScore).WithAlpha(0.65f);
+                worldHandle.DrawCircle(candidateMapPosition.Position, CandidateRadius, color);
+            }
+
+            if (data.Chosen is { } chosen)
+            {
+                var chosenCoordinates = _entityManager.GetCoordinates(chosen);
+                var chosenMapPosition = _transformSystem.ToMapCoordinates(chosenCoordinates);
+
+                if (chosenMapPosition.MapId == args.MapId)
+                {
+                    worldHandle.DrawCircle(chosenMapPosition.Position, ChosenRadius, Color.Yellow.WithAlpha(0.9f), false);
+                }
+            }
+        }
+    }
+}

--- a/Content.Client/_KS14/NPC/TacticalPositionDebugOverlay.cs
+++ b/Content.Client/_KS14/NPC/TacticalPositionDebugOverlay.cs
@@ -1,7 +1,5 @@
-using Content.Shared._KS14.NPC;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
-using Robust.Shared.Maths;
 
 namespace Content.Client._KS14.NPC;
 
@@ -9,24 +7,16 @@ namespace Content.Client._KS14.NPC;
 /// Draws the most recent tactical position debug frame per NPC: every scored candidate (colored red-to-green
 /// by score), the chosen candidate (highlighted), and live claim-table entries (clearance-radius circles).
 /// </summary>
-public sealed class TacticalPositionDebugOverlay : Overlay
+public sealed partial class TacticalPositionDebugOverlay : Overlay
 {
-    private readonly TacticalPositionDebugSystem _system;
-    private readonly IEntityManager _entityManager;
-    private readonly SharedTransformSystem _transformSystem;
+    [Dependency] private IEntityManager _entityManager = default!;
+    [Dependency] private TacticalPositionDebugSystem _system = default!;
+    [Dependency] private SharedTransformSystem _transformSystem = default!;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
     private const float CandidateRadius = 0.12f;
     private const float ChosenRadius = 0.2f;
-
-    public TacticalPositionDebugOverlay(TacticalPositionDebugSystem system, IEntityManager entityManager, IEyeManager eyeManager)
-    {
-        _system = system;
-        _entityManager = entityManager;
-        _eyeManager = eyeManager;
-        _transformSystem = entityManager.System<SharedTransformSystem>();
-    }
 
     protected override void Draw(in OverlayDrawArgs args)
     {

--- a/Content.Client/_KS14/NPC/TacticalPositionDebugSystem.cs
+++ b/Content.Client/_KS14/NPC/TacticalPositionDebugSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._KS14.IoC;
 using Content.Shared._KS14.NPC;
 using Robust.Client.Graphics;
 using Robust.Shared.Map;
@@ -10,11 +11,11 @@ namespace Content.Client._KS14.NPC;
 /// (see <see cref="Content.Server._KS14.NPC.Systems.NpcTacticalPositionDebugSystem"/>) and adds/removes
 /// <see cref="TacticalPositionDebugOverlay"/> in response to the server telling us whether we're subscribed.
 /// </summary>
-public sealed class TacticalPositionDebugSystem : EntitySystem
+public sealed partial class TacticalPositionDebugSystem : EntitySystem
 {
     [Dependency] private IOverlayManager _overlayManager = default!;
-    [Dependency] private IEyeManager _eyeManager = default!;
     [Dependency] private IGameTiming _gameTiming = default!;
+    [Dependency] private SystemCollectionHookManager _systemCollectionHookManager = default!;
 
     private static readonly TimeSpan FrameLifetime = TimeSpan.FromSeconds(2);
 
@@ -22,11 +23,25 @@ public sealed class TacticalPositionDebugSystem : EntitySystem
 
     public IReadOnlyDictionary<NetEntity, (TimeSpan Expiry, TacticalPositionDebugDataMessage Data)> Frames => _frames;
 
+    private TacticalPositionDebugOverlay? _overlay;
+    private bool _enabled;
+
     public override void Initialize()
     {
         base.Initialize();
         SubscribeNetworkEvent<TacticalPositionDebugStateMessage>(OnState);
         SubscribeNetworkEvent<TacticalPositionDebugDataMessage>(OnData);
+
+        _systemCollectionHookManager.HookAction(OnDependenciesReady);
+    }
+
+    private void OnDependenciesReady(IDependencyCollection dependencyCollection)
+    {
+        _overlay = new TacticalPositionDebugOverlay();
+        dependencyCollection.InjectDependencies(_overlay, oneOff: true);
+
+        if (_enabled)
+            _overlayManager.AddOverlay(_overlay);
     }
 
     public override void Shutdown()
@@ -63,10 +78,12 @@ public sealed class TacticalPositionDebugSystem : EntitySystem
 
     private void OnState(TacticalPositionDebugStateMessage message)
     {
+        _enabled = message.Enabled;
+
         if (message.Enabled)
         {
-            if (!_overlayManager.HasOverlay<TacticalPositionDebugOverlay>())
-                _overlayManager.AddOverlay(new TacticalPositionDebugOverlay(this, EntityManager, _eyeManager));
+            if (_overlay != null && !_overlayManager.HasOverlay<TacticalPositionDebugOverlay>())
+                _overlayManager.AddOverlay(_overlay);
         }
         else
         {

--- a/Content.Client/_KS14/NPC/TacticalPositionDebugSystem.cs
+++ b/Content.Client/_KS14/NPC/TacticalPositionDebugSystem.cs
@@ -1,0 +1,82 @@
+using Content.Shared._KS14.NPC;
+using Robust.Client.Graphics;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Client._KS14.NPC;
+
+/// <summary>
+/// Client side of the tactical position debug overlay. Stores the most recent debug frame per NPC
+/// (see <see cref="Content.Server._KS14.NPC.Systems.NpcTacticalPositionDebugSystem"/>) and adds/removes
+/// <see cref="TacticalPositionDebugOverlay"/> in response to the server telling us whether we're subscribed.
+/// </summary>
+public sealed class TacticalPositionDebugSystem : EntitySystem
+{
+    [Dependency] private IOverlayManager _overlayManager = default!;
+    [Dependency] private IEyeManager _eyeManager = default!;
+    [Dependency] private IGameTiming _gameTiming = default!;
+
+    private static readonly TimeSpan FrameLifetime = TimeSpan.FromSeconds(2);
+
+    private readonly Dictionary<NetEntity, (TimeSpan Expiry, TacticalPositionDebugDataMessage Data)> _frames = new();
+
+    public IReadOnlyDictionary<NetEntity, (TimeSpan Expiry, TacticalPositionDebugDataMessage Data)> Frames => _frames;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<TacticalPositionDebugStateMessage>(OnState);
+        SubscribeNetworkEvent<TacticalPositionDebugDataMessage>(OnData);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _frames.Clear();
+        _overlayManager.RemoveOverlay<TacticalPositionDebugOverlay>();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _gameTiming.RealTime;
+        List<NetEntity>? expired = null;
+
+        foreach (var (owner, frame) in _frames)
+        {
+            if (now < frame.Expiry)
+                continue;
+
+            expired ??= new List<NetEntity>();
+            expired.Add(owner);
+        }
+
+        if (expired == null)
+            return;
+
+        foreach (var owner in expired)
+        {
+            _frames.Remove(owner);
+        }
+    }
+
+    private void OnState(TacticalPositionDebugStateMessage message)
+    {
+        if (message.Enabled)
+        {
+            if (!_overlayManager.HasOverlay<TacticalPositionDebugOverlay>())
+                _overlayManager.AddOverlay(new TacticalPositionDebugOverlay(this, EntityManager, _eyeManager));
+        }
+        else
+        {
+            _frames.Clear();
+            _overlayManager.RemoveOverlay<TacticalPositionDebugOverlay>();
+        }
+    }
+
+    private void OnData(TacticalPositionDebugDataMessage message)
+    {
+        _frames[message.Owner] = (_gameTiming.RealTime + FrameLifetime, message);
+    }
+}

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Content.Server._KS14.NPC.Components;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Pathfinding;
 using Content.Server.NPC.Systems;
@@ -175,6 +176,19 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             }
 
             comp.CurrentPath = new Queue<PathPoly>(result.Path);
+        }
+
+        // KS14: ANK: Never means ConditionalShutdown will never run via the HTN task/plan lifecycle (that's
+        // the point - the movement survives task/plan transitions), so nothing would otherwise remove
+        // TargetKey/PathfindKey or unregister steering once we actually arrive. NpcMoveToCleanupSystem
+        // watches for the steering we just registered to stop and finishes that cleanup itself.
+        if (ShutdownState == HTNPlanState.Never)
+        {
+            var cleanup = _entManager.EnsureComponent<NpcPendingMoveCleanupComponent>(uid);
+            cleanup.TargetKey = TargetKey;
+            cleanup.PathfindKey = PathfindKey;
+            cleanup.RemoveKeyOnFinish = RemoveKeyOnFinish;
+            cleanup.Coordinates = targetCoordinates;
         }
     }
 

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Klovn.Tactical.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Klovn.Tactical.cs
@@ -1,0 +1,157 @@
+// KS14: added in this fork
+using System.Threading;
+using System.Threading.Tasks;
+using Content.Server._KS14.NPC.Pathfinding;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Utility;
+
+namespace Content.Server.NPC.Pathfinding;
+
+public sealed partial class PathfindingSystem
+{
+    /// <summary>
+    /// Flood-fills the poly graph from <paramref name="reference"/> out to <paramref name="maxRange"/>,
+    /// returning up to <paramref name="maxCandidates"/> reachable <see cref="PathPoly"/> nodes for tactical
+    /// position scoring (camping/retreat/advance). Unlike <see cref="GetRandomPath"/>, this does not
+    /// reconstruct a route - callers only need candidate endpoints.
+    /// </summary>
+    public async Task<List<PathPoly>> GetTacticalCandidates(
+        EntityUid entity,
+        EntityCoordinates reference,
+        float maxRange,
+        int maxCandidates,
+        CancellationToken cancelToken,
+        PathFlags flags = PathFlags.None)
+    {
+        var layer = 0;
+        var mask = 0;
+
+        if (TryComp<FixturesComponent>(entity, out var fixtures))
+        {
+            (layer, mask) = _physics.GetHardCollision(entity, fixtures);
+        }
+
+        var request = new TacticalPathRequest(reference, maxRange, maxCandidates, flags, layer, mask, cancelToken);
+        _pathRequests.Add(request);
+
+        await request.Task;
+
+        if (!request.Task.IsCompletedSuccessfully)
+            return new List<PathPoly>();
+
+        // Same context as MoveToOperator/PickAccessibleOperator's awaits and not synchronously blocking.
+#pragma warning disable RA0004
+        var result = request.Task.Result;
+#pragma warning restore RA0004
+
+        if (result != PathResult.Path)
+            return new List<PathPoly>();
+
+        return request.Candidates;
+    }
+
+    private PathResult UpdateTacticalPath(TacticalPathRequest request)
+    {
+        if (request.Task.IsCanceled)
+        {
+            return PathResult.NoPath;
+        }
+
+        PathPoly? currentNode;
+
+        if (!request.Started)
+        {
+            request.Frontier = new PriorityQueue<(float, PathPoly)>(PathPolyComparer);
+            request.Started = true;
+        }
+        else
+        {
+            if (request.Frontier.Count == 0)
+            {
+                return PathResult.NoPath;
+            }
+
+            (_, currentNode) = request.Frontier.Peek();
+
+            if (!currentNode.IsValid())
+            {
+                return PathResult.NoPath;
+            }
+        }
+
+        DebugTools.Assert(!request.Task.IsCompleted);
+        request.Stopwatch.Restart();
+
+        var startNode = GetPoly(request.Start);
+
+        if (startNode == null)
+        {
+            return PathResult.NoPath;
+        }
+
+        request.Frontier.Add((0.0f, startNode));
+        request.CostSoFar[startNode] = 0.0f;
+        var count = 0;
+
+        while (request.Frontier.Count > 0 && count < NodeLimit && request.CostSoFar.Count < request.MaxCandidates)
+        {
+            if (count % 20 == 0 && count > 0 && request.Stopwatch.Elapsed > PathTime)
+            {
+                return PathResult.Continuing;
+            }
+
+            count++;
+
+            (_, currentNode) = request.Frontier.Take();
+
+            foreach (var neighbor in currentNode.Neighbors)
+            {
+                var tileCost = GetTileCost(request, currentNode, neighbor);
+
+                if (tileCost.Equals(0f))
+                {
+                    continue;
+                }
+
+                var gScore = request.CostSoFar[currentNode] + tileCost;
+
+                // Candidates further than ExpansionRange are excluded entirely rather than just capped -
+                // unlike GetRandomPath's BFS, tactical candidates are scored by distance-from-reference so
+                // an unbounded flood would waste time enumerating positions no consideration curve wants.
+                if (gScore > request.ExpansionRange)
+                {
+                    continue;
+                }
+
+                if (request.CostSoFar.TryGetValue(neighbor, out var nextValue) && gScore >= nextValue)
+                {
+                    continue;
+                }
+
+                request.CostSoFar[neighbor] = gScore;
+                request.Frontier.Add((gScore, neighbor));
+            }
+        }
+
+        if (request.CostSoFar.Count == 0)
+        {
+            return PathResult.NoPath;
+        }
+
+        request.Candidates.Clear();
+
+        foreach (var (poly, _) in request.CostSoFar)
+        {
+            if (!poly.IsValid())
+                continue;
+
+            request.Candidates.Add(poly);
+
+            if (request.Candidates.Count >= request.MaxCandidates)
+                break;
+        }
+
+        return PathResult.Path;
+    }
+}

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Klovn.Tactical.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Klovn.Tactical.cs
@@ -92,9 +92,14 @@ public sealed partial class PathfindingSystem
 
         request.Frontier.Add((0.0f, startNode));
         request.CostSoFar[startNode] = 0.0f;
+        request.DistanceSoFar[startNode] = 0.0f;
         var count = 0;
 
-        while (request.Frontier.Count > 0 && count < NodeLimit && request.CostSoFar.Count < request.MaxCandidates)
+        // Gated by NodeLimit alone, not MaxCandidates - capping expansion by the requested candidate count
+        // would let a single large room exhaust the budget on its own floor tiles before the frontier ever
+        // dequeues (and expands past) a farther doorway, making anything beyond it unreachable even though
+        // it's well within ExpansionRange. MaxCandidates instead truncates the materialized list below.
+        while (request.Frontier.Count > 0 && count < NodeLimit)
         {
             if (count % 20 == 0 && count > 0 && request.Stopwatch.Elapsed > PathTime)
             {
@@ -114,15 +119,19 @@ public sealed partial class PathfindingSystem
                     continue;
                 }
 
-                var gScore = request.CostSoFar[currentNode] + tileCost;
+                // Raw spatial distance, independent of tileCost's door/smash/climb weighting - a door adds a
+                // large additive modifier to tileCost (see GetTileCost) so that costlier routes are deprioritized
+                // by the priority queue, but that same weighting must not be mistaken for physical distance, or
+                // any candidate past a door (even one the NPC can freely open) would get cut off as if it were
+                // far away.
+                var distance = request.DistanceSoFar[currentNode] + OctileDistance(currentNode, neighbor);
 
-                // Candidates further than ExpansionRange are excluded entirely rather than just capped -
-                // unlike GetRandomPath's BFS, tactical candidates are scored by distance-from-reference so
-                // an unbounded flood would waste time enumerating positions no consideration curve wants.
-                if (gScore > request.ExpansionRange)
+                if (distance > request.ExpansionRange)
                 {
                     continue;
                 }
+
+                var gScore = request.CostSoFar[currentNode] + tileCost;
 
                 if (request.CostSoFar.TryGetValue(neighbor, out var nextValue) && gScore >= nextValue)
                 {
@@ -130,6 +139,7 @@ public sealed partial class PathfindingSystem
                 }
 
                 request.CostSoFar[neighbor] = gScore;
+                request.DistanceSoFar[neighbor] = distance;
                 request.Frontier.Add((gScore, neighbor));
             }
         }

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Managers;
+using Content.Server._KS14.NPC.Pathfinding; // KS14
 using Content.Shared.Destructible; // Trauma - destructible moved to shared
 using Content.Server.NPC.Systems;
 using Content.Shared.Access.Components;
@@ -126,6 +127,11 @@ namespace Content.Server.NPC.Pathfinding
                         case BFSPathRequest bfs:
                             results[i] = UpdateBFSPath(_random, bfs);
                             break;
+                        // KS14 start: dispatch for tactical position candidate enumeration
+                        case TacticalPathRequest tactical:
+                            results[i] = UpdateTacticalPath(tactical);
+                            break;
+                        // KS14 end
                         default:
                             throw new NotImplementedException();
                     }

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -169,7 +169,7 @@ public sealed partial class NPCUtilitySystem : EntitySystem
         return result;
     }
 
-    private float GetScore(IUtilityCurve curve, float conScore)
+    internal /* KS14: private -> internal, reused by TacticalPositionOperator */ float GetScore(IUtilityCurve curve, float conScore)
     {
         // KS14: ANK: the entire point of HighScore and LowScore instead of concrete 1f and 0f is so that some bool curves can be lenient instead of being binary fails (a false would be able to heavily discourage some utility target, but not outright eliminate it)
 
@@ -420,7 +420,7 @@ public sealed partial class NPCUtilitySystem : EntitySystem
         }
     }
 
-    private float GetAdjustedScore(float score, int considerations)
+    internal /* KS14: private -> internal, reused by TacticalPositionOperator */ float GetAdjustedScore(float score, int considerations)
     {
         /*
         * Now using the geometric mean

--- a/Content.Server/_KS14/NPC/Commands/TacticalPositionDebugCommand.cs
+++ b/Content.Server/_KS14/NPC/Commands/TacticalPositionDebugCommand.cs
@@ -1,0 +1,32 @@
+using Content.Server.Administration;
+using Content.Server._KS14.NPC.Systems;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._KS14.NPC.Commands;
+
+/// <summary>
+/// Toggles the tactical position debug overlay (candidate scores, chosen spot, live claims) for the
+/// invoking player. See <see cref="NpcTacticalPositionDebugSystem"/>.
+/// </summary>
+[AdminCommand(AdminFlags.Debug)]
+public sealed partial class TacticalPositionDebugCommand : LocalizedEntityCommands
+{
+    [Dependency] private NpcTacticalPositionDebugSystem _npcTacticalPositionDebugSystem = default!;
+
+    public override string Command => "ks_tacticalposdebug";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (shell.Player is not { } player)
+        {
+            shell.WriteError(Loc.GetString("cmd-ks_tacticalposdebug-no-session"));
+            return;
+        }
+
+        var enabled = _npcTacticalPositionDebugSystem.Toggle(player);
+        shell.WriteLine(Loc.GetString(enabled
+            ? "cmd-ks_tacticalposdebug-enabled"
+            : "cmd-ks_tacticalposdebug-disabled"));
+    }
+}

--- a/Content.Server/_KS14/NPC/Commands/TacticalPositionDebugCommand.cs
+++ b/Content.Server/_KS14/NPC/Commands/TacticalPositionDebugCommand.cs
@@ -1,4 +1,5 @@
 using Content.Server.Administration;
+using Content.Server.NPC.HTN;
 using Content.Server._KS14.NPC.Systems;
 using Content.Shared.Administration;
 using Robust.Shared.Console;
@@ -7,7 +8,8 @@ namespace Content.Server._KS14.NPC.Commands;
 
 /// <summary>
 /// Toggles the tactical position debug overlay (candidate scores, chosen spot, live claims) for the
-/// invoking player. See <see cref="NpcTacticalPositionDebugSystem"/>.
+/// invoking player - either for every NPC using the query, or scoped to a single entity given by argument.
+/// See <see cref="NpcTacticalPositionDebugSystem"/>.
 /// </summary>
 [AdminCommand(AdminFlags.Debug)]
 public sealed partial class TacticalPositionDebugCommand : LocalizedEntityCommands
@@ -24,9 +26,45 @@ public sealed partial class TacticalPositionDebugCommand : LocalizedEntityComman
             return;
         }
 
-        var enabled = _npcTacticalPositionDebugSystem.Toggle(player);
-        shell.WriteLine(Loc.GetString(enabled
-            ? "cmd-ks_tacticalposdebug-enabled"
-            : "cmd-ks_tacticalposdebug-disabled"));
+        if (args.Length > 1)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        EntityUid? target = null;
+
+        if (args.Length == 1)
+        {
+            if (!NetEntity.TryParse(args[0], out var netTarget) || !EntityManager.TryGetEntity(netTarget, out var targetUid))
+            {
+                shell.WriteError(Loc.GetString("cmd-ks_tacticalposdebug-invalid-entity", ("entity", args[0])));
+                return;
+            }
+
+            target = targetUid;
+        }
+
+        var (enabled, resultTarget) = _npcTacticalPositionDebugSystem.Toggle(player, target);
+
+        if (!enabled)
+        {
+            shell.WriteLine(Loc.GetString("cmd-ks_tacticalposdebug-disabled"));
+            return;
+        }
+
+        shell.WriteLine(resultTarget is { } trackedUid
+            ? Loc.GetString("cmd-ks_tacticalposdebug-enabled-single", ("entity", EntityManager.ToPrettyString(trackedUid)))
+            : Loc.GetString("cmd-ks_tacticalposdebug-enabled-all"));
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+            return CompletionResult.Empty;
+
+        return CompletionResult.FromHintOptions(
+            CompletionHelper.Components<HTNComponent>(args[0], EntityManager),
+            Loc.GetString("cmd-ks_tacticalposdebug-entity-hint"));
     }
 }

--- a/Content.Server/_KS14/NPC/Components/NpcPendingMoveCleanupComponent.cs
+++ b/Content.Server/_KS14/NPC/Components/NpcPendingMoveCleanupComponent.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.Map;
+
+namespace Content.Server._KS14.NPC.Components;
+
+/// <summary>
+///     Attached by MoveToOperator when its shutdownState is Never, since in that case the normal HTN
+///     task/plan shutdown hooks never call its ConditionalShutdown - the operator instead relies on
+///     NpcMoveToCleanupSystem to remove its target/pathfind blackboard keys and unregister steering once the
+///     movement it started actually concludes (arrives, fails to path, or gets taken over by something else
+///     re-registering steering).
+/// </summary>
+[RegisterComponent]
+public sealed partial class NpcPendingMoveCleanupComponent : Component
+{
+    public string TargetKey = default!;
+    public string PathfindKey = default!;
+    public bool RemoveKeyOnFinish;
+
+    /// <summary>
+    /// The coordinates we registered steering towards. If the NPC's current steering no longer points here,
+    /// something else has taken over movement and we should only clean up our keys, not touch steering.
+    /// </summary>
+    public EntityCoordinates Coordinates;
+}

--- a/Content.Server/_KS14/NPC/Components/NpcTacticalPositionClaimComponent.cs
+++ b/Content.Server/_KS14/NPC/Components/NpcTacticalPositionClaimComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.Analyzers;
+using Robust.Shared.Map;
+
+namespace Content.Server._KS14.NPC.Components;
+
+/// <summary>
+///     Marks an NPC as having reserved a dynamically-picked tactical position (camping/retreat/advance
+///     destination), so other NPCs querying TacticalPositionOperator avoid/discourage nearby candidates.
+///     Added/refreshed by NpcTacticalPositionClaimSystem.Claim and removed on release or TTL expiry.
+/// </summary>
+[RegisterComponent, AutoGenerateComponentPause]
+public sealed partial class NpcTacticalPositionClaimComponent : Component
+{
+    [ViewVariables(VVAccess.ReadOnly)]
+    public EntityCoordinates Coordinates;
+
+    [AutoPausedField]
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan ExpiresAt;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public float ClearanceRadius;
+}

--- a/Content.Server/_KS14/NPC/HTN/PrimitiveTasks/Operators/TacticalPositionOperator.cs
+++ b/Content.Server/_KS14/NPC/HTN/PrimitiveTasks/Operators/TacticalPositionOperator.cs
@@ -1,0 +1,306 @@
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using Content.Server.Examine;
+using Content.Server._KS14.NPC.Systems;
+using Content.Shared._KS14.NPC;
+using Content.Server.NPC;
+using Content.Server.NPC.HTN;
+using Content.Server.NPC.HTN.PrimitiveTasks;
+using Content.Server.NPC.HTN.PrimitiveTasks.Operators;
+using Content.Server.NPC.Pathfinding;
+using Content.Server.NPC.Queries;
+using Content.Server.NPC.Queries.Curves;
+using Content.Server.NPC.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Random;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server._KS14.NPC.HTN.PrimitiveTasks.Operators;
+
+/// <summary>
+/// Picks a camping/retreat/advance destination for an NPC. Tries an existing mapper-placed marker
+/// <see cref="UtilityQueryPrototype"/> first (<see cref="MarkerPrototype"/>) so hand-tuned spots keep priority;
+/// if that yields nothing, falls back to a dynamic navmesh-based tactical position query: candidate points are
+/// enumerated from the reachable poly graph around <see cref="ReferenceCoordinatesKey"/>
+/// (<see cref="PathfindingSystem.GetTacticalCandidates"/>) and scored with the same utility-curve machinery
+/// used for markers, plus a reservation-table penalty so concurrent NPCs don't converge on the same spot.
+/// </summary>
+public sealed partial class TacticalPositionOperator : HTNOperator, IHtnConditionalShutdown
+{
+    [Dependency] private IEntityManager _entityManager = default!;
+    [Dependency] private IRobustRandom _robustRandom = default!;
+    private PathfindingSystem _pathfindingSystem = default!;
+    private NPCUtilitySystem _npcUtilitySystem = default!;
+    private NpcTacticalPositionClaimSystem _npcTacticalPositionClaimSystem = default!;
+    private NpcTacticalPositionDebugSystem _npcTacticalPositionDebugSystem = default!;
+    private ExamineSystem _examineSystem = default!;
+    private SharedTransformSystem _transformSystem = default!;
+
+    /// <summary>
+    /// Marker-phase utility query to try first (e.g. an existing ComponentQuery against NpcCampingSpot).
+    /// Null/omitted skips the marker phase entirely and always uses the dynamic algorithm.
+    /// </summary>
+    [DataField("markerProto", customTypeSerializer: typeof(PrototypeIdSerializer<UtilityQueryPrototype>))]
+    public string? MarkerPrototype;
+
+    [DataField] public string Key = "TacticalTarget";
+
+    [DataField("keyCoordinates")]
+    public string KeyCoordinates = "TacticalTargetCoordinates";
+
+    /// <summary>
+    /// Blackboard coordinates the candidate flood originates from, and distance is scored against.
+    /// </summary>
+    [DataField(required: true)]
+    public string ReferenceCoordinatesKey = string.Empty;
+
+    [DataField] public float MaxRange = 15f;
+
+    [DataField] public int MaxCandidates = 64;
+
+    [DataField] public IUtilityCurve DistanceCurve = new PresetCurve { Preset = "KsTargetDistanceLessClose" };
+
+    /// <summary>
+    /// If set, adds an LOS consideration between the candidate and this coordinates key. Wrap
+    /// <see cref="LosCurve"/> with an InverseBoolCurve in YAML to prefer concealment instead of visibility.
+    /// </summary>
+    [DataField] public string? LosReferenceCoordinatesKey;
+
+    [DataField] public float LosRadius = 10f;
+
+    [DataField] public IUtilityCurve LosCurve = new BoolCurve();
+
+    /// <summary>
+    /// If set, adds a directional-cone consideration (owner facing this coordinates key, is the candidate
+    /// within Angle degrees of that direction).
+    /// </summary>
+    [DataField] public string? FovReferenceCoordinatesKey;
+
+    [DataField] public float FovAngle = 65f;
+
+    [DataField] public IUtilityCurve FovCurve = new BoolCurve();
+
+    /// <summary>
+    /// 0 disables the random-jitter consideration entirely.
+    /// </summary>
+    [DataField] public float RandomProbability;
+
+    [DataField] public float ClaimClearanceRadius = 2.5f;
+
+    /// <summary>
+    /// Blackboard float key read at claim time to size the claim's TTL (e.g. CampingTime/AdvanceTime).
+    /// </summary>
+    [DataField] public string ClaimDurationKey = "CampingTime";
+
+    [DataField] public float ClaimTtlBuffer = 5f;
+
+    /// <summary>
+    /// Mirrors <see cref="UtilityOperator.InvalidatePlanOnNoHighest"/>: if true, the plan is invalidated when
+    /// neither the marker phase nor the dynamic phase find anything. Otherwise the plan succeeds with no
+    /// target written to the blackboard.
+    /// </summary>
+    [DataField] public bool InvalidatePlanOnNoHighest = true;
+
+    /// <inheritdoc/>
+    public HTNPlanState ShutdownState => HTNPlanState.TaskFinished;
+
+    public override void Initialize(IEntitySystemManager sysManager)
+    {
+        base.Initialize(sysManager);
+        _pathfindingSystem = sysManager.GetEntitySystem<PathfindingSystem>();
+        _npcUtilitySystem = sysManager.GetEntitySystem<NPCUtilitySystem>();
+        _npcTacticalPositionClaimSystem = sysManager.GetEntitySystem<NpcTacticalPositionClaimSystem>();
+        _npcTacticalPositionDebugSystem = sysManager.GetEntitySystem<NpcTacticalPositionDebugSystem>();
+        _examineSystem = sysManager.GetEntitySystem<ExamineSystem>();
+        _transformSystem = sysManager.GetEntitySystem<SharedTransformSystem>();
+    }
+
+    public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(
+        NPCBlackboard blackboard, CancellationToken cancelToken)
+    {
+        var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+
+        // Phase 1: markers-first. Reuses the existing marker utilityQuery prototype unmodified so mapper
+        // intent always wins when a marker scores > 0; no claim is registered for marker picks, since
+        // anti-stacking for the marker pool is out of scope (mappers already space markers out).
+        if (MarkerPrototype is not null)
+        {
+            var markerResult = _npcUtilitySystem.GetEntities(blackboard, MarkerPrototype);
+            var markerTarget = markerResult.GetHighest();
+
+            if (markerTarget.IsValid())
+            {
+                return (true, new Dictionary<string, object>
+                {
+                    { Key, markerTarget },
+                    { KeyCoordinates, new EntityCoordinates(markerTarget, Vector2.Zero) },
+                });
+            }
+        }
+
+        // Phase 2: dynamic fallback via the pathfinding poly graph.
+        if (!blackboard.TryGetValue<EntityCoordinates>(ReferenceCoordinatesKey, out var reference, _entityManager))
+            return (!InvalidatePlanOnNoHighest, new Dictionary<string, object>());
+
+        var candidates = await _pathfindingSystem.GetTacticalCandidates(
+            owner, reference, MaxRange, MaxCandidates, cancelToken, _pathfindingSystem.GetFlags(blackboard));
+
+        if (candidates.Count == 0)
+            return (!InvalidatePlanOnNoHighest, new Dictionary<string, object>());
+
+        PathPoly? best = null;
+        var bestScore = 0f;
+
+        // Lazy: the debug candidate list is only allocated/populated while a debug overlay is actually
+        // subscribed - see NpcTacticalPositionDebugSystem. Every NPC replanning this task every tick would
+        // otherwise pay for a debug payload nobody is looking at.
+        var debugCandidates = _npcTacticalPositionDebugSystem.AnyDebugging
+            ? new List<TacticalPositionDebugCandidate>(candidates.Count)
+            : null;
+
+        foreach (var candidate in candidates)
+        {
+            var score = ScoreCandidate(blackboard, owner, candidate, reference);
+            debugCandidates?.Add(new TacticalPositionDebugCandidate(_entityManager.GetNetCoordinates(candidate.Coordinates), score));
+
+            if (score > bestScore)
+            {
+                bestScore = score;
+                best = candidate;
+            }
+        }
+
+        if (best is null)
+        {
+            if (debugCandidates is not null)
+            {
+                _npcTacticalPositionDebugSystem.SendDebugFrame(owner, debugCandidates, null,
+                    _npcTacticalPositionClaimSystem.GetAllClaimsForDebug().ConvertAll(ToDebugClaim));
+            }
+
+            return (!InvalidatePlanOnNoHighest, new Dictionary<string, object>());
+        }
+
+        _npcTacticalPositionClaimSystem.Claim(owner, best.Coordinates, GetClaimTtl(blackboard), ClaimClearanceRadius);
+
+        if (debugCandidates is not null)
+        {
+            _npcTacticalPositionDebugSystem.SendDebugFrame(owner, debugCandidates, best.Coordinates,
+                _npcTacticalPositionClaimSystem.GetAllClaimsForDebug().ConvertAll(ToDebugClaim));
+        }
+
+        return (true, new Dictionary<string, object>
+        {
+            { KeyCoordinates, best.Coordinates },
+        });
+    }
+
+    private TacticalPositionDebugClaim ToDebugClaim((EntityCoordinates Coordinates, float ClearanceRadius) claim)
+    {
+        return new TacticalPositionDebugClaim(_entityManager.GetNetCoordinates(claim.Coordinates), claim.ClearanceRadius);
+    }
+
+    private float ScoreCandidate(NPCBlackboard blackboard, EntityUid owner, PathPoly candidate, EntityCoordinates reference)
+    {
+        var considerationCount = 1 // distance, always applied
+            + (LosReferenceCoordinatesKey is not null ? 1 : 0)
+            + (FovReferenceCoordinatesKey is not null ? 1 : 0)
+            + (RandomProbability > 0f ? 1 : 0)
+            + 1; // claim penalty, always applied
+
+        var score = 1f;
+
+        if (!candidate.Coordinates.TryDistance(_entityManager, _transformSystem, reference, out var distance))
+            return 0f;
+
+        var visionRadius = blackboard.GetValueOrDefault<float>(blackboard.GetVisionRadiusKey(_entityManager), _entityManager);
+        var distanceRaw = Math.Clamp(distance / MathF.Max(visionRadius, 0.01f), 0f, 1f);
+        score *= _npcUtilitySystem.GetAdjustedScore(_npcUtilitySystem.GetScore(DistanceCurve, distanceRaw), considerationCount);
+
+        if (score <= 0f)
+            return 0f;
+
+        if (LosReferenceCoordinatesKey is not null &&
+            blackboard.TryGetValue<EntityCoordinates>(LosReferenceCoordinatesKey, out var losReference, _entityManager))
+        {
+            var losRaw = _examineSystem.InRangeUnOccluded(
+                _transformSystem.ToMapCoordinates(candidate.Coordinates),
+                _transformSystem.ToMapCoordinates(losReference),
+                LosRadius + 0.5f,
+                null) ? 1f : 0f;
+
+            score *= _npcUtilitySystem.GetAdjustedScore(_npcUtilitySystem.GetScore(LosCurve, losRaw), considerationCount);
+
+            if (score <= 0f)
+                return 0f;
+        }
+
+        if (FovReferenceCoordinatesKey is not null &&
+            blackboard.TryGetValue<EntityCoordinates>(FovReferenceCoordinatesKey, out var fovReference, _entityManager))
+        {
+            var fovRaw = EvaluateFov(owner, candidate.Coordinates, fovReference, FovAngle);
+            score *= _npcUtilitySystem.GetAdjustedScore(_npcUtilitySystem.GetScore(FovCurve, fovRaw), considerationCount);
+
+            if (score <= 0f)
+                return 0f;
+        }
+
+        if (RandomProbability > 0f)
+        {
+            var jitterRaw = _robustRandom.Prob(RandomProbability) ? 1f : 0f;
+            score *= _npcUtilitySystem.GetAdjustedScore(_npcUtilitySystem.GetScore(new BoolCurve(), jitterRaw), considerationCount);
+
+            if (score <= 0f)
+                return 0f;
+        }
+
+        var claimPenalty = _npcTacticalPositionClaimSystem.GetClaimPenalty(candidate.Coordinates, ClaimClearanceRadius);
+        score *= _npcUtilitySystem.GetAdjustedScore(claimPenalty, considerationCount);
+
+        return score;
+    }
+
+    /// <summary>
+    /// Mirrors CoordinatesInFOVCon's dot-product cone check: is the direction from
+    /// <paramref name="owner"/> to <paramref name="candidate"/> within <paramref name="angleDegrees"/>
+    /// of the direction from <paramref name="owner"/> to <paramref name="reference"/>?
+    /// </summary>
+    private float EvaluateFov(EntityUid owner, EntityCoordinates candidate, EntityCoordinates reference, float angleDegrees)
+    {
+        var ownerPosition = _transformSystem.GetWorldPosition(owner);
+        var candidatePosition = _transformSystem.ToWorldPosition(candidate);
+        var referencePosition = _transformSystem.ToWorldPosition(reference);
+
+        var forward = candidatePosition - ownerPosition;
+        Vector2Helpers.Normalize(ref forward);
+
+        var toReference = referencePosition - ownerPosition;
+        Vector2Helpers.Normalize(ref toReference);
+
+        var dot = Vector2.Dot(forward, toReference);
+
+        var halfFovRad = MathF.PI * (angleDegrees / 2f) / 180f;
+        var threshold = MathF.Cos(halfFovRad);
+
+        return dot >= threshold ? 1f : 0f;
+    }
+
+    private TimeSpan GetClaimTtl(NPCBlackboard blackboard)
+    {
+        var duration = blackboard.GetValueOrDefault<float>(ClaimDurationKey, _entityManager);
+        return TimeSpan.FromSeconds(duration + ClaimTtlBuffer);
+    }
+
+    public void ConditionalShutdown(NPCBlackboard blackboard)
+    {
+        _npcTacticalPositionClaimSystem.ReleaseClaim(blackboard.GetValue<EntityUid>(NPCBlackboard.Owner));
+    }
+
+    public override void TaskShutdown(NPCBlackboard blackboard, HTNOperatorStatus status)
+    {
+        base.TaskShutdown(blackboard, status);
+        _npcTacticalPositionClaimSystem.ReleaseClaim(blackboard.GetValue<EntityUid>(NPCBlackboard.Owner));
+    }
+}

--- a/Content.Server/_KS14/NPC/HTN/PrimitiveTasks/Operators/TacticalPositionOperator.cs
+++ b/Content.Server/_KS14/NPC/HTN/PrimitiveTasks/Operators/TacticalPositionOperator.cs
@@ -31,12 +31,12 @@ public sealed partial class TacticalPositionOperator : HTNOperator, IHtnConditio
 {
     [Dependency] private IEntityManager _entityManager = default!;
     [Dependency] private IRobustRandom _robustRandom = default!;
-    private PathfindingSystem _pathfindingSystem = default!;
-    private NPCUtilitySystem _npcUtilitySystem = default!;
-    private NpcTacticalPositionClaimSystem _npcTacticalPositionClaimSystem = default!;
-    private NpcTacticalPositionDebugSystem _npcTacticalPositionDebugSystem = default!;
-    private ExamineSystem _examineSystem = default!;
-    private SharedTransformSystem _transformSystem = default!;
+    [Dependency] private PathfindingSystem _pathfindingSystem = default!;
+    [Dependency] private NPCUtilitySystem _npcUtilitySystem = default!;
+    [Dependency] private NpcTacticalPositionClaimSystem _npcTacticalPositionClaimSystem = default!;
+    [Dependency] private NpcTacticalPositionDebugSystem _npcTacticalPositionDebugSystem = default!;
+    [Dependency] private ExamineSystem _examineSystem = default!;
+    [Dependency] private SharedTransformSystem _transformSystem = default!;
 
     /// <summary>
     /// Marker-phase utility query to try first (e.g. an existing ComponentQuery against NpcCampingSpot).
@@ -105,17 +105,6 @@ public sealed partial class TacticalPositionOperator : HTNOperator, IHtnConditio
 
     /// <inheritdoc/>
     public HTNPlanState ShutdownState => HTNPlanState.TaskFinished;
-
-    public override void Initialize(IEntitySystemManager sysManager)
-    {
-        base.Initialize(sysManager);
-        _pathfindingSystem = sysManager.GetEntitySystem<PathfindingSystem>();
-        _npcUtilitySystem = sysManager.GetEntitySystem<NPCUtilitySystem>();
-        _npcTacticalPositionClaimSystem = sysManager.GetEntitySystem<NpcTacticalPositionClaimSystem>();
-        _npcTacticalPositionDebugSystem = sysManager.GetEntitySystem<NpcTacticalPositionDebugSystem>();
-        _examineSystem = sysManager.GetEntitySystem<ExamineSystem>();
-        _transformSystem = sysManager.GetEntitySystem<SharedTransformSystem>();
-    }
 
     public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(
         NPCBlackboard blackboard, CancellationToken cancelToken)

--- a/Content.Server/_KS14/NPC/HTN/PrimitiveTasks/Operators/TacticalPositionOperator.cs
+++ b/Content.Server/_KS14/NPC/HTN/PrimitiveTasks/Operators/TacticalPositionOperator.cs
@@ -156,7 +156,7 @@ public sealed partial class TacticalPositionOperator : HTNOperator, IHtnConditio
         // Lazy: the debug candidate list is only allocated/populated while a debug overlay is actually
         // subscribed - see NpcTacticalPositionDebugSystem. Every NPC replanning this task every tick would
         // otherwise pay for a debug payload nobody is looking at.
-        var debugCandidates = _npcTacticalPositionDebugSystem.AnyDebugging
+        var debugCandidates = _npcTacticalPositionDebugSystem.IsTracking(owner)
             ? new List<TacticalPositionDebugCandidate>(candidates.Count)
             : null;
 

--- a/Content.Server/_KS14/NPC/Pathfinding/TacticalPathRequest.cs
+++ b/Content.Server/_KS14/NPC/Pathfinding/TacticalPathRequest.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using Content.Server.NPC.Pathfinding;
+using Robust.Shared.Map;
+
+namespace Content.Server._KS14.NPC.Pathfinding;
+
+/// <summary>
+/// Floods the poly graph from <see cref="PathRequest.Start"/> and collects up to <see cref="MaxCandidates"/>
+/// reachable <see cref="PathPoly"/> nodes, for <see cref="TacticalPositionOperator"/>'s dynamic
+/// camping/retreat/advance-position scoring. Unlike <see cref="BFSPathRequest"/>, this does not reconstruct
+/// a route - callers only need candidate endpoints, not a path to one of them.
+/// </summary>
+public sealed class TacticalPathRequest : PathRequest
+{
+    /// <summary>
+    /// How far away we're allowed to expand in distance.
+    /// </summary>
+    public float ExpansionRange;
+
+    /// <summary>
+    /// How many candidate nodes to return at most.
+    /// </summary>
+    public int MaxCandidates;
+
+    public readonly List<PathPoly> Candidates = new();
+
+    public TacticalPathRequest(
+        EntityCoordinates start,
+        float expansionRange,
+        int maxCandidates,
+        PathFlags flags,
+        int layer,
+        int mask,
+        CancellationToken cancelToken) : base(start, flags, layer, mask, cancelToken)
+    {
+        ExpansionRange = expansionRange;
+        MaxCandidates = maxCandidates;
+    }
+}

--- a/Content.Server/_KS14/NPC/Pathfinding/TacticalPathRequest.cs
+++ b/Content.Server/_KS14/NPC/Pathfinding/TacticalPathRequest.cs
@@ -24,6 +24,14 @@ public sealed class TacticalPathRequest : PathRequest
 
     public readonly List<PathPoly> Candidates = new();
 
+    /// <summary>
+    /// Raw octile distance accumulated from <see cref="PathRequest.Start"/>, separate from
+    /// <see cref="PathRequest.CostSoFar"/>'s door/smash/climb-weighted traversal cost - used to cap flood
+    /// expansion by actual spatial range instead of cutting candidates off early just because a door or other
+    /// costly tile sits between them and the start.
+    /// </summary>
+    public readonly Dictionary<PathPoly, float> DistanceSoFar = new();
+
     public TacticalPathRequest(
         EntityCoordinates start,
         float expansionRange,

--- a/Content.Server/_KS14/NPC/Systems/NpcMoveToCleanupSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcMoveToCleanupSystem.cs
@@ -1,0 +1,61 @@
+using Content.Server._KS14.NPC.Components;
+using Content.Server.NPC.Components;
+using Content.Server.NPC.HTN;
+using Content.Server.NPC.Pathfinding;
+using Content.Server.NPC.Systems;
+using Robust.Shared.Map;
+
+namespace Content.Server._KS14.NPC.Systems;
+
+/// <summary>
+///     Finishes MoveToOperator's cleanup for movement tasks that opted out of the normal HTN task/plan
+///     shutdown hooks via shutdownState: Never (background movement that survives task/plan transitions),
+///     once the steering they started has actually stopped - either it arrived/failed to path, or something
+///     else took over steering for the NPC. See <see cref="NpcPendingMoveCleanupComponent"/>.
+/// </summary>
+public sealed partial class NpcMoveToCleanupSystem : EntitySystem
+{
+    [Dependency] private NPCSteeringSystem _steeringSystem = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<NpcPendingMoveCleanupComponent, HTNComponent>();
+
+        while (query.MoveNext(out var uid, out var cleanup, out var htn))
+        {
+            if (!TryComp<NPCSteeringComponent>(uid, out var steering))
+            {
+                Finish(uid, cleanup, htn, unregister: false);
+                continue;
+            }
+
+            if (!steering.Coordinates.Equals(cleanup.Coordinates))
+            {
+                // Something else re-registered steering over ours - leave it alone, just clean up our keys.
+                Finish(uid, cleanup, htn, unregister: false);
+                continue;
+            }
+
+            if (steering.Status == SteeringStatus.Moving)
+                continue;
+
+            Finish(uid, cleanup, htn, unregister: true);
+        }
+    }
+
+    private void Finish(EntityUid uid, NpcPendingMoveCleanupComponent cleanup, HTNComponent htn, bool unregister)
+    {
+        var blackboard = htn.Blackboard;
+        blackboard.Remove<PathResultEvent>(cleanup.PathfindKey);
+
+        if (cleanup.RemoveKeyOnFinish)
+            blackboard.Remove<EntityCoordinates>(cleanup.TargetKey);
+
+        if (unregister)
+            _steeringSystem.Unregister(uid);
+
+        RemComp<NpcPendingMoveCleanupComponent>(uid);
+    }
+}

--- a/Content.Server/_KS14/NPC/Systems/NpcMoveToCleanupSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcMoveToCleanupSystem.cs
@@ -23,31 +23,31 @@ public sealed partial class NpcMoveToCleanupSystem : EntitySystem
 
         var query = EntityQueryEnumerator<NpcPendingMoveCleanupComponent, HTNComponent>();
 
-        while (query.MoveNext(out var uid, out var cleanup, out var htn))
+        while (query.MoveNext(out var uid, out var cleanupComponent, out var htnComponent))
         {
             if (!TryComp<NPCSteeringComponent>(uid, out var steering))
             {
-                Finish(uid, cleanup, htn, unregister: false);
+                Finish(uid, cleanupComponent, htnComponent, unregister: false);
                 continue;
             }
 
-            if (!steering.Coordinates.Equals(cleanup.Coordinates))
+            if (!steering.Coordinates.Equals(cleanupComponent.Coordinates))
             {
                 // Something else re-registered steering over ours - leave it alone, just clean up our keys.
-                Finish(uid, cleanup, htn, unregister: false);
+                Finish(uid, cleanupComponent, htnComponent, unregister: false);
                 continue;
             }
 
             if (steering.Status == SteeringStatus.Moving)
                 continue;
 
-            Finish(uid, cleanup, htn, unregister: true);
+            Finish(uid, cleanupComponent, htnComponent, unregister: true);
         }
     }
 
-    private void Finish(EntityUid uid, NpcPendingMoveCleanupComponent cleanup, HTNComponent htn, bool unregister)
+    private void Finish(EntityUid uid, NpcPendingMoveCleanupComponent cleanup, HTNComponent htnComponent, bool unregister)
     {
-        var blackboard = htn.Blackboard;
+        var blackboard = htnComponent.Blackboard;
         blackboard.Remove<PathResultEvent>(cleanup.PathfindKey);
 
         if (cleanup.RemoveKeyOnFinish)

--- a/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionClaimSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionClaimSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._KS14.NPC.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
 
@@ -5,40 +6,32 @@ namespace Content.Server._KS14.NPC.Systems;
 
 /// <summary>
 /// Reservation table preventing NPCs using <see cref="Content.Server._KS14.NPC.HTN.PrimitiveTasks.Operators.TacticalPositionOperator"/>
-/// from converging on the same dynamically-picked camping/retreat/advance position.
-///
-/// NOT thread-safe: every read/write happens from main-thread HTN callbacks (Plan/ConditionalShutdown/TaskShutdown)
-/// or this system's own Update - never from PathfindingSystem's parallel path-processing.
+/// from converging on the same dynamically-picked camping/retreat/advance position. Backed by
+/// <see cref="NpcTacticalPositionClaimComponent"/> rather than a system-owned lookup table: a claim is then
+/// entity-lifetime-bound for free (deleting the owning NPC removes its claim automatically, no leak to sweep),
+/// and reading every live claim reuses the same query enumerator every other NPC subsystem iterates with.
 /// </summary>
 public sealed partial class NpcTacticalPositionClaimSystem : EntitySystem
 {
     [Dependency] private IGameTiming _gameTiming = default!;
     [Dependency] private SharedTransformSystem _transformSystem = default!;
 
-    private readonly Dictionary<EntityUid, TacticalClaim> _claims = new();
-
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
         var now = _gameTiming.CurTime;
-        List<EntityUid>? expired = null;
+        var query = EntityQueryEnumerator<NpcTacticalPositionClaimComponent>();
 
-        foreach (var (owner, claim) in _claims)
+        // Removing the current entity's own component mid-iteration is safe here: RemComp marks it Deleted
+        // rather than mutating the backing dictionary, so the enumerator just skips it on the next MoveNext.
+        // Same pattern as NPCPerceptionSystem.RecentlyInjected.cs's TTL sweep.
+        while (query.MoveNext(out var uid, out var claim))
         {
             if (now < claim.ExpiresAt)
                 continue;
 
-            expired ??= new List<EntityUid>();
-            expired.Add(owner);
-        }
-
-        if (expired == null)
-            return;
-
-        foreach (var owner in expired)
-        {
-            _claims.Remove(owner);
+            RemComp<NpcTacticalPositionClaimComponent>(uid);
         }
     }
 
@@ -47,7 +40,10 @@ public sealed partial class NpcTacticalPositionClaimSystem : EntitySystem
     /// </summary>
     public void Claim(EntityUid owner, EntityCoordinates coordinates, TimeSpan ttl, float clearanceRadius)
     {
-        _claims[owner] = new TacticalClaim(owner, coordinates, _gameTiming.CurTime + ttl, clearanceRadius);
+        var claim = EnsureComp<NpcTacticalPositionClaimComponent>(owner);
+        claim.Coordinates = coordinates;
+        claim.ExpiresAt = _gameTiming.CurTime + ttl;
+        claim.ClearanceRadius = clearanceRadius;
     }
 
     /// <summary>
@@ -57,7 +53,7 @@ public sealed partial class NpcTacticalPositionClaimSystem : EntitySystem
     /// </summary>
     public void ReleaseClaim(EntityUid owner)
     {
-        _claims.Remove(owner);
+        RemComp<NpcTacticalPositionClaimComponent>(owner);
     }
 
     /// <summary>
@@ -67,13 +63,11 @@ public sealed partial class NpcTacticalPositionClaimSystem : EntitySystem
     /// </summary>
     public float GetClaimPenalty(EntityCoordinates candidate, float clearanceRadius)
     {
-        if (_claims.Count == 0)
-            return 1f;
-
         var candidateMap = _transformSystem.ToMapCoordinates(candidate);
         var penalty = 1f;
 
-        foreach (var claim in _claims.Values)
+        var query = EntityQueryEnumerator<NpcTacticalPositionClaimComponent>();
+        while (query.MoveNext(out _, out var claim))
         {
             var claimMap = _transformSystem.ToMapCoordinates(claim.Coordinates);
 
@@ -102,15 +96,14 @@ public sealed partial class NpcTacticalPositionClaimSystem : EntitySystem
     /// </summary>
     public List<(EntityCoordinates Coordinates, float ClearanceRadius)> GetAllClaimsForDebug()
     {
-        var claims = new List<(EntityCoordinates, float)>(_claims.Count);
+        var claims = new List<(EntityCoordinates, float)>();
+        var query = EntityQueryEnumerator<NpcTacticalPositionClaimComponent>();
 
-        foreach (var claim in _claims.Values)
+        while (query.MoveNext(out _, out var claim))
         {
             claims.Add((claim.Coordinates, claim.ClearanceRadius));
         }
 
         return claims;
     }
-
-    private readonly record struct TacticalClaim(EntityUid Owner, EntityCoordinates Coordinates, TimeSpan ExpiresAt, float ClearanceRadius);
 }

--- a/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionClaimSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionClaimSystem.cs
@@ -1,0 +1,116 @@
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Server._KS14.NPC.Systems;
+
+/// <summary>
+/// Reservation table preventing NPCs using <see cref="Content.Server._KS14.NPC.HTN.PrimitiveTasks.Operators.TacticalPositionOperator"/>
+/// from converging on the same dynamically-picked camping/retreat/advance position.
+///
+/// NOT thread-safe: every read/write happens from main-thread HTN callbacks (Plan/ConditionalShutdown/TaskShutdown)
+/// or this system's own Update - never from PathfindingSystem's parallel path-processing.
+/// </summary>
+public sealed partial class NpcTacticalPositionClaimSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _gameTiming = default!;
+    [Dependency] private SharedTransformSystem _transformSystem = default!;
+
+    private readonly Dictionary<EntityUid, TacticalClaim> _claims = new();
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _gameTiming.CurTime;
+        List<EntityUid>? expired = null;
+
+        foreach (var (owner, claim) in _claims)
+        {
+            if (now < claim.ExpiresAt)
+                continue;
+
+            expired ??= new List<EntityUid>();
+            expired.Add(owner);
+        }
+
+        if (expired == null)
+            return;
+
+        foreach (var owner in expired)
+        {
+            _claims.Remove(owner);
+        }
+    }
+
+    /// <summary>
+    /// Registers (or refreshes) a claim on behalf of <paramref name="owner"/>.
+    /// </summary>
+    public void Claim(EntityUid owner, EntityCoordinates coordinates, TimeSpan ttl, float clearanceRadius)
+    {
+        _claims[owner] = new TacticalClaim(owner, coordinates, _gameTiming.CurTime + ttl, clearanceRadius);
+    }
+
+    /// <summary>
+    /// Releases <paramref name="owner"/>'s claim early, if any. Called from
+    /// <see cref="Content.Server.NPC.HTN.IHtnConditionalShutdown"/>/<c>TaskShutdown</c> as a fast path on top
+    /// of the TTL sweep in <see cref="Update"/>.
+    /// </summary>
+    public void ReleaseClaim(EntityUid owner)
+    {
+        _claims.Remove(owner);
+    }
+
+    /// <summary>
+    /// Returns a penalty multiplier in [0, 1] for how "claimed" the given candidate position is, considering
+    /// every live claim on the same grid within its (or the caller's) clearance radius. 1 = unclaimed/clear,
+    /// 0 = coincides with a live claim.
+    /// </summary>
+    public float GetClaimPenalty(EntityCoordinates candidate, float clearanceRadius)
+    {
+        if (_claims.Count == 0)
+            return 1f;
+
+        var candidateMap = _transformSystem.ToMapCoordinates(candidate);
+        var penalty = 1f;
+
+        foreach (var claim in _claims.Values)
+        {
+            var claimMap = _transformSystem.ToMapCoordinates(claim.Coordinates);
+
+            if (claimMap.MapId != candidateMap.MapId)
+                continue;
+
+            var radius = MathF.Max(clearanceRadius, claim.ClearanceRadius);
+            var distance = (claimMap.Position - candidateMap.Position).Length();
+
+            if (distance >= radius)
+                continue;
+
+            // Linearly ramp the penalty down to 0 as the candidate approaches the claimed spot, rather than a
+            // hard cutoff, so nearby-but-distinct candidates are merely discouraged instead of excluded outright.
+            var proximity = 1f - distance / radius;
+            penalty = MathF.Min(penalty, 1f - proximity);
+        }
+
+        return Math.Clamp(penalty, 0f, 1f);
+    }
+
+    /// <summary>
+    /// Snapshots every live claim's coordinates and clearance radius, for debug visualization only. Callers
+    /// (see <see cref="Content.Server._KS14.NPC.Systems.NpcTacticalPositionDebugSystem"/>) are expected to
+    /// only call this while a debug overlay is actually subscribed, so this allocation stays off the hot path.
+    /// </summary>
+    public List<(EntityCoordinates Coordinates, float ClearanceRadius)> GetAllClaimsForDebug()
+    {
+        var claims = new List<(EntityCoordinates, float)>(_claims.Count);
+
+        foreach (var claim in _claims.Values)
+        {
+            claims.Add((claim.Coordinates, claim.ClearanceRadius));
+        }
+
+        return claims;
+    }
+
+    private readonly record struct TacticalClaim(EntityUid Owner, EntityCoordinates Coordinates, TimeSpan ExpiresAt, float ClearanceRadius);
+}

--- a/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionDebugSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionDebugSystem.cs
@@ -8,20 +8,23 @@ namespace Content.Server._KS14.NPC.Systems;
 
 /// <summary>
 /// Tracks which player sessions have <see cref="Content.Server._KS14.NPC.Commands.TacticalPositionDebugCommand"/>
-/// toggled on, and lets <see cref="Content.Server._KS14.NPC.HTN.PrimitiveTasks.Operators.TacticalPositionOperator"/>
-/// push debug frames (candidate scores, the chosen candidate, live claims) to them.
+/// toggled on - either for every NPC using the tactical position query, or scoped to a single tracked entity -
+/// and lets <see cref="Content.Server._KS14.NPC.HTN.PrimitiveTasks.Operators.TacticalPositionOperator"/> push
+/// debug frames (candidate scores, the chosen candidate, live claims) to them.
 ///
-/// Deliberately lazy: <see cref="AnyDebugging"/> is the gate the operator checks before doing any of the
-/// extra bookkeeping (recording every candidate's score, snapshotting the claim table) needed to build a
-/// debug frame - none of that work happens while nobody is watching.
+/// Deliberately lazy: <see cref="IsTracking"/> is the gate the operator checks, per-owner, before doing any of
+/// the extra bookkeeping (recording every candidate's score, snapshotting the claim table) needed to build a
+/// debug frame - none of that work happens for an NPC nobody is watching, including when every subscriber is
+/// scoped to a different single entity.
 /// </summary>
 public sealed partial class NpcTacticalPositionDebugSystem : EntitySystem
 {
     [Dependency] private IPlayerManager _playerManager = default!;
 
-    private readonly HashSet<ICommonSession> _debuggingSessions = new();
-
-    public bool AnyDebugging => _debuggingSessions.Count > 0;
+    /// <summary>
+    /// Null value = tracking every entity; a concrete value = scoped to that one entity only.
+    /// </summary>
+    private readonly Dictionary<ICommonSession, EntityUid?> _debuggingSessions = new();
 
     public override void Initialize()
     {
@@ -37,23 +40,48 @@ public sealed partial class NpcTacticalPositionDebugSystem : EntitySystem
     }
 
     /// <summary>
-    /// Flips debugging on/off for <paramref name="session"/> and returns the new state.
+    /// Returns true if any subscribed session would receive a debug frame for <paramref name="owner"/> -
+    /// either tracking everything, or scoped specifically to it. Callers should skip building a debug frame
+    /// entirely when this is false.
     /// </summary>
-    public bool Toggle(ICommonSession session)
+    public bool IsTracking(EntityUid owner)
     {
-        var enabled = !_debuggingSessions.Remove(session);
+        foreach (var target in _debuggingSessions.Values)
+        {
+            if (target is null || target == owner)
+                return true;
+        }
 
-        if (enabled)
-            _debuggingSessions.Add(session);
-
-        RaiseNetworkEvent(new TacticalPositionDebugStateMessage { Enabled = enabled }, session.Channel);
-        return enabled;
+        return false;
     }
 
     /// <summary>
-    /// Broadcasts one debug frame to every subscribed session. Only call this when <see cref="AnyDebugging"/>
-    /// is true - callers are expected to skip building the (potentially sizeable) candidate list entirely
-    /// otherwise.
+    /// Toggles debugging for <paramref name="session"/>. If <paramref name="target"/> matches the session's
+    /// current scope (both null, or the same entity), debugging is turned off; otherwise the session is
+    /// (re)subscribed scoped to <paramref name="target"/> (null = every entity). Returns the resulting state.
+    /// </summary>
+    public (bool Enabled, EntityUid? Target) Toggle(ICommonSession session, EntityUid? target)
+    {
+        if (_debuggingSessions.TryGetValue(session, out var currentTarget) && currentTarget == target)
+        {
+            _debuggingSessions.Remove(session);
+            RaiseNetworkEvent(new TacticalPositionDebugStateMessage { Enabled = false }, session.Channel);
+            return (false, target);
+        }
+
+        _debuggingSessions[session] = target;
+        RaiseNetworkEvent(new TacticalPositionDebugStateMessage
+        {
+            Enabled = true,
+            Target = target is { } uid ? GetNetEntity(uid) : null,
+        }, session.Channel);
+        return (true, target);
+    }
+
+    /// <summary>
+    /// Broadcasts one debug frame to every subscribed session tracking <paramref name="owner"/> (either
+    /// untargeted, or scoped to it specifically). Only call this when <see cref="IsTracking"/> for that owner
+    /// is true - callers are expected to skip building the (potentially sizeable) candidate list otherwise.
     /// </summary>
     public void SendDebugFrame(
         EntityUid owner,
@@ -64,16 +92,21 @@ public sealed partial class NpcTacticalPositionDebugSystem : EntitySystem
         if (_debuggingSessions.Count == 0)
             return;
 
-        var message = new TacticalPositionDebugDataMessage
-        {
-            Owner = GetNetEntity(owner),
-            Candidates = candidates,
-            Chosen = chosen is { } coordinates ? GetNetCoordinates(coordinates) : null,
-            Claims = new List<TacticalPositionDebugClaim>(claims),
-        };
+        TacticalPositionDebugDataMessage? message = null;
 
-        foreach (var session in _debuggingSessions)
+        foreach (var (session, target) in _debuggingSessions)
         {
+            if (target is { } specificTarget && specificTarget != owner)
+                continue;
+
+            message ??= new TacticalPositionDebugDataMessage
+            {
+                Owner = GetNetEntity(owner),
+                Candidates = candidates,
+                Chosen = chosen is { } coordinates ? GetNetCoordinates(coordinates) : null,
+                Claims = new List<TacticalPositionDebugClaim>(claims),
+            };
+
             RaiseNetworkEvent(message, session.Channel);
         }
     }

--- a/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionDebugSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionDebugSystem.cs
@@ -1,0 +1,88 @@
+using Content.Shared._KS14.NPC;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Server._KS14.NPC.Systems;
+
+/// <summary>
+/// Tracks which player sessions have <see cref="Content.Server._KS14.NPC.Commands.TacticalPositionDebugCommand"/>
+/// toggled on, and lets <see cref="Content.Server._KS14.NPC.HTN.PrimitiveTasks.Operators.TacticalPositionOperator"/>
+/// push debug frames (candidate scores, the chosen candidate, live claims) to them.
+///
+/// Deliberately lazy: <see cref="AnyDebugging"/> is the gate the operator checks before doing any of the
+/// extra bookkeeping (recording every candidate's score, snapshotting the claim table) needed to build a
+/// debug frame - none of that work happens while nobody is watching.
+/// </summary>
+public sealed partial class NpcTacticalPositionDebugSystem : EntitySystem
+{
+    [Dependency] private IPlayerManager _playerManager = default!;
+
+    private readonly HashSet<ICommonSession> _debuggingSessions = new();
+
+    public bool AnyDebugging => _debuggingSessions.Count > 0;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
+        _debuggingSessions.Clear();
+    }
+
+    /// <summary>
+    /// Flips debugging on/off for <paramref name="session"/> and returns the new state.
+    /// </summary>
+    public bool Toggle(ICommonSession session)
+    {
+        var enabled = !_debuggingSessions.Remove(session);
+
+        if (enabled)
+            _debuggingSessions.Add(session);
+
+        RaiseNetworkEvent(new TacticalPositionDebugStateMessage { Enabled = enabled }, session.Channel);
+        return enabled;
+    }
+
+    /// <summary>
+    /// Broadcasts one debug frame to every subscribed session. Only call this when <see cref="AnyDebugging"/>
+    /// is true - callers are expected to skip building the (potentially sizeable) candidate list entirely
+    /// otherwise.
+    /// </summary>
+    public void SendDebugFrame(
+        EntityUid owner,
+        List<TacticalPositionDebugCandidate> candidates,
+        EntityCoordinates? chosen,
+        IReadOnlyList<TacticalPositionDebugClaim> claims)
+    {
+        if (_debuggingSessions.Count == 0)
+            return;
+
+        var message = new TacticalPositionDebugDataMessage
+        {
+            Owner = GetNetEntity(owner),
+            Candidates = candidates,
+            Chosen = chosen is { } coordinates ? GetNetCoordinates(coordinates) : null,
+            Claims = new List<TacticalPositionDebugClaim>(claims),
+        };
+
+        foreach (var session in _debuggingSessions)
+        {
+            RaiseNetworkEvent(message, session.Channel);
+        }
+    }
+
+    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
+    {
+        if (e.NewStatus != SessionStatus.Disconnected)
+            return;
+
+        _debuggingSessions.Remove(e.Session);
+    }
+}

--- a/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionDebugSystem.cs
+++ b/Content.Server/_KS14/NPC/Systems/NpcTacticalPositionDebugSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._KS14.NPC;
+using Content.Shared.GameTicking;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
@@ -30,6 +31,7 @@ public sealed partial class NpcTacticalPositionDebugSystem : EntitySystem
     {
         base.Initialize();
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
     }
 
     public override void Shutdown()
@@ -117,5 +119,20 @@ public sealed partial class NpcTacticalPositionDebugSystem : EntitySystem
             return;
 
         _debuggingSessions.Remove(e.Session);
+    }
+
+    /// <summary>
+    /// Unlike <see cref="OnPlayerStatusChanged"/>, sessions stay connected across a round restart, so a silent
+    /// clear here would leave their client-side overlay stuck showing stale data from the previous round -
+    /// tell each of them explicitly before dropping the server-side state.
+    /// </summary>
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
+    {
+        foreach (var session in _debuggingSessions.Keys)
+        {
+            RaiseNetworkEvent(new TacticalPositionDebugStateMessage { Enabled = false }, session.Channel);
+        }
+
+        _debuggingSessions.Clear();
     }
 }

--- a/Content.Shared/_KS14/IoC/SystemCollectionHookManager.cs
+++ b/Content.Shared/_KS14/IoC/SystemCollectionHookManager.cs
@@ -4,6 +4,11 @@ namespace Content.Shared._KS14.IoC;
 
 // TODO LCDC: somehow make engine PR to make this engine-based or otherwise publicly accessible
 
+/// <summary>
+///     Class that helps you retrieve <see cref="IEntitySystemManager.DependencyCollection"/>, which
+///         lets you resolve <see cref="EntityQuery<>>"/> and <see cref="EntitySystem"/>, unlike
+///         the <see cref="IDependencyCollection"/> used by <see cref="IoCManager"/>.
+/// </summary>
 public sealed partial class SystemCollectionHookManager
 {
     [Dependency] private INetManager _netManager = default!;

--- a/Content.Shared/_KS14/IoC/SystemCollectionHookManager.cs
+++ b/Content.Shared/_KS14/IoC/SystemCollectionHookManager.cs
@@ -5,9 +5,9 @@ namespace Content.Shared._KS14.IoC;
 // TODO LCDC: somehow make engine PR to make this engine-based or otherwise publicly accessible
 
 /// <summary>
-///     Class that helps you retrieve <see cref="IEntitySystemManager.DependencyCollection"/>, which
-///         lets you resolve <see cref="EntityQuery<>>"/> and <see cref="EntitySystem"/>, unlike
-///         the <see cref="IDependencyCollection"/> used by <see cref="IoCManager"/>.
+///     Class that helps you retrieve <see cref="IEntitySystemManager.DependencyCollection"/>, which, upon being used to inject
+///         into a class, will resolve <see cref="EntityQuery<>>"/> and <see cref="EntitySystem"/>, unlike
+///         the <see cref="IDependencyCollection"/> used by the default <see cref="IoCManager"/>.
 /// </summary>
 public sealed partial class SystemCollectionHookManager
 {
@@ -20,7 +20,10 @@ public sealed partial class SystemCollectionHookManager
         _sawmill = Logger.GetSawmill("sys.collectionhook.man");
     }
 
-    /// <inheritdoc cref="EntitySystemManager.DependencyCollection"/>
+    /// <summary>
+    ///     Dependency collection that contains all loaded systems and component queries,
+    ///         unlike that of <see cref="IoCManager"/>.
+    /// </summary>
     [Access(Other = AccessPermissions.ReadExecute)]
     public IDependencyCollection DependencyCollection => _entitySystemManager.DependencyCollection;
     private Action<IDependencyCollection>? _onSystemCollectionAvailable = null;
@@ -76,6 +79,7 @@ public sealed partial class SystemCollectionHookManager
     }
 
     /// <inheritdoc cref="HookAction(Action)"/>
+    /// <param name="act">Is given <see cref="SystemCollectionHookManager.DependencyCollection"/>: a dependency collection that already contains all loaded systems and component queries.</param>
     public void HookAction(Action<IDependencyCollection> act)
     {
         if (IsProperlyInitialised())

--- a/Content.Shared/_KS14/NPC/TacticalPositionDebugMessages.cs
+++ b/Content.Shared/_KS14/NPC/TacticalPositionDebugMessages.cs
@@ -5,12 +5,17 @@ namespace Content.Shared._KS14.NPC;
 
 /// <summary>
 /// Sent server -> the toggling client only, telling it whether it is now subscribed to
-/// <see cref="TacticalPositionDebugDataMessage"/>s.
+/// <see cref="TacticalPositionDebugDataMessage"/>s, and whether that subscription is scoped to a single entity.
 /// </summary>
 [Serializable, NetSerializable]
 public sealed class TacticalPositionDebugStateMessage : EntityEventArgs
 {
     public bool Enabled;
+
+    /// <summary>
+    /// Null = subscribed to every entity; otherwise scoped to this one entity only.
+    /// </summary>
+    public NetEntity? Target;
 }
 
 /// <summary>

--- a/Content.Shared/_KS14/NPC/TacticalPositionDebugMessages.cs
+++ b/Content.Shared/_KS14/NPC/TacticalPositionDebugMessages.cs
@@ -1,0 +1,34 @@
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._KS14.NPC;
+
+/// <summary>
+/// Sent server -> the toggling client only, telling it whether it is now subscribed to
+/// <see cref="TacticalPositionDebugDataMessage"/>s.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class TacticalPositionDebugStateMessage : EntityEventArgs
+{
+    public bool Enabled;
+}
+
+/// <summary>
+/// Sent server -> every subscribed client whenever a TacticalPositionOperator finishes scoring a batch of
+/// dynamically-flooded candidates. Only ever built/sent while at least one client is subscribed - see
+/// <see cref="Content.Server._KS14.NPC.Systems.NpcTacticalPositionDebugSystem"/>.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class TacticalPositionDebugDataMessage : EntityEventArgs
+{
+    public NetEntity Owner;
+    public List<TacticalPositionDebugCandidate> Candidates = new();
+    public NetCoordinates? Chosen;
+    public List<TacticalPositionDebugClaim> Claims = new();
+}
+
+[Serializable, NetSerializable]
+public readonly record struct TacticalPositionDebugCandidate(NetCoordinates Coordinates, float Score);
+
+[Serializable, NetSerializable]
+public readonly record struct TacticalPositionDebugClaim(NetCoordinates Coordinates, float ClearanceRadius);

--- a/Klovn/Docs/npc_navmesh.md
+++ b/Klovn/Docs/npc_navmesh.md
@@ -1,0 +1,147 @@
+# NPC Tactical Position Query (dynamic camping/retreat/advance)
+
+This document explains the dynamic, navmesh-based system NPCs use to pick camping, retreat, and
+advance destinations, and how it relates to the older marker-based system it supplements.
+
+## Background
+
+Klovnstation 14's operative AI historically picked camping/retreat/advance destinations only from
+manually-placed marker entities (`KsMarkerNpcCamping`, tagged with the (misnamed)
+`NpcCampingSpotComponent`). Mappers place these by hand on maps, and NPCs query for the nearest
+suitable one via a `UtilityOperator` running a `ComponentQuery`-based `utilityQuery` prototype.
+
+This has two costs:
+
+- Every combat zone needs hand-placed, hand-tuned markers before NPCs behave well there.
+- Markers are static: they don't gain or lose tactical value when the map changes (a wall gets
+  destroyed, a door opens), even though the game's own pathfinding graph already tracks that live.
+
+The dynamic system adds a **fallback**: when no marker scores well, the NPC instead queries the
+existing navmesh-like poly graph maintained by `PathfindingSystem` for reachable candidate
+positions near a reference point, scores them with the same style of utility curves already used
+for markers, and picks the best one - subject to a reservation table so concurrent NPCs don't
+converge on the same spot. Markers are left fully functional and are always tried first, so mapper
+intent still wins wherever markers exist, and no map files need to change.
+
+## Algorithm
+
+**Navmesh-based tactical position query**, reusing `PathfindingSystem`'s poly graph instead of
+inventing a new spatial structure:
+
+1. A pathfinding request (`TacticalPathRequest`) floods the poly graph (Dijkstra-style, mirroring
+   the existing `UpdateBFSPath`) from a reference coordinate out to a max range, and returns the
+   visited `PathPoly` nodes as candidates (capped count) instead of collapsing to one random route
+   like `GetRandomPath` does.
+2. Each candidate's coordinate is scored inline: distance-from-reference, LOS/occlusion via
+   `ExamineSystemShared.InRangeUnOccluded`, an optional facing-cone (FOV) check, random jitter, and
+   a claim-table penalty - combined via the same running-geometric-mean approach
+   `NPCUtilitySystem` already uses for markers, for consistency.
+3. The highest-scoring candidate wins; a claim is registered against it so other concurrent
+   queries avoid/penalize nearby positions for a short time.
+
+This directly solves "markers don't react to environment": the poly graph is already
+reachability-aware and already updates as the map changes, so no new environment-tracking code was
+needed - only a new way to enumerate it.
+
+Requests go through `PathfindingSystem`'s existing time-sliced queue (`_pathRequests`, a shared
+3ms/tick budget across all pathfinding work), the same mechanism `PickAccessibleOperator`/
+`GetRandomPath` already use, so this does not introduce a new source of per-tick cost spikes.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `Content.Server/_KS14/NPC/Pathfinding/TacticalPathRequest.cs` | `PathRequest` subclass that collects flood-fill candidates instead of reconstructing one route. |
+| `Content.Server/NPC/Pathfinding/PathfindingSystem.Klovn.Tactical.cs` | Upstream-namespace partial file adding `GetTacticalCandidates(...)` and the BFS-style flood (`UpdateTacticalPath`). Marked `// KS14: added in this fork` since it extends an upstream class outside `_KS14/`. |
+| `Content.Server/_KS14/NPC/Systems/NpcTacticalPositionClaimSystem.cs` | The reservation/claim table preventing NPCs from converging on the same dynamically-picked spot. |
+| `Content.Server/_KS14/NPC/HTN/PrimitiveTasks/Operators/TacticalPositionOperator.cs` | The single YAML-tunable `HTNOperator`: tries the marker query first, falls back to the dynamic algorithm. |
+| `Content.Server/NPC/Pathfinding/PathfindingSystem.cs` | Marked upstream edit: dispatches `TacticalPathRequest` in `Update()`'s switch. |
+| `Content.Server/NPC/Systems/NPCUtilitySystem.cs` | Marked upstream edit: `GetScore`/`GetAdjustedScore` changed `private -> internal` so the operator reuses the exact same curve-evaluation math instead of duplicating it. |
+| `Resources/Prototypes/_KsModule/NPCs/Operative/operative_hostile.yml`, `operative_retreat.yml`, `operative_advance.yml` | Camping/retreat/advance HTN tasks, each configuring `TacticalPositionOperator` with behavior-specific reference keys and curves. Existing marker `utilityQuery` prototypes are untouched and still used for the marker phase. |
+| `Resources/Prototypes/_KsModule/Entities/Mobs/Operative/base.yml` | Per-mob blackboard tuning (`CampingTime`, `AdvanceTime`, `RetreatClaimDuration`, etc.) that sizes claim durations. |
+
+## How `TacticalPositionOperator` works
+
+`TacticalPositionOperator` is a single operator reused (with different `[DataField]`s) for
+camping, retreat, and advance - not three separate C# classes. Its `Plan()` runs in two phases:
+
+1. **Marker phase** (optional, via `MarkerProto`): runs the existing marker `utilityQuery`
+   unmodified through `NPCUtilitySystem.GetEntities`. If it finds a valid highest-score marker,
+   that wins immediately - mapper-placed spots always take priority over computed ones. No claim
+   is registered for marker picks (anti-stacking is out of scope for the marker pool; mappers
+   already space markers out by hand).
+2. **Dynamic phase** (fallback): reads `ReferenceCoordinatesKey` from the blackboard (e.g.
+   `LastTargetCoordinates` for camping, `OwnerCoordinates` for retreat/advance), floods the poly
+   graph via `PathfindingSystem.GetTacticalCandidates`, and scores every candidate with whichever
+   of the following considerations are configured:
+   - **Distance** (always applied) - via `DistanceCurve` against `ReferenceCoordinatesKey`.
+   - **LOS** (optional, via `LosReferenceCoordinatesKey`/`LosRadius`/`LosCurve`) - occlusion check
+     between the candidate and a reference point. Wrap `LosCurve` in an `InverseBoolCurve` in YAML
+     to prefer concealment instead of visibility.
+   - **FOV** (optional, via `FovReferenceCoordinatesKey`/`FovAngle`/`FovCurve`) - is the candidate
+     within a facing cone from the owner toward a reference point.
+   - **Random jitter** (optional, via `RandomProbability`) - adds variety so NPCs don't always
+     pick the literal highest-scoring tile.
+   - **Claim penalty** (always applied) - queried from `NpcTacticalPositionClaimSystem`.
+
+   The winning candidate's coordinates are written to `KeyCoordinates` (feeding directly into
+   `MoveToOperator.TargetKey`, following the existing task-local key convention, e.g.
+   `CampingTargetCoordinates`/`RetreatTargetCoordinates`), and a claim is registered for it.
+
+`TacticalPositionOperator` also implements `IHtnConditionalShutdown` and overrides
+`TaskShutdown`, both releasing the NPC's claim early when its task ends - a fast path on top of
+the claim table's own TTL sweep.
+
+## The claim/reservation table
+
+`NpcTacticalPositionClaimSystem` prevents NPCs from converging on the same computed spot - a
+problem the old marker system didn't have (a finite, mapper-spread pool of markers naturally
+spread NPCs out; a "pick the best point" algorithm without this table would repeatedly return the
+same optimal tile to every NPC asking).
+
+- One claim per owning NPC (`Dictionary<EntityUid, TacticalClaim>`), so claiming/releasing is O(1).
+- `GetClaimPenalty` linearly scans live claims on the same map, discouraging (not hard-excluding)
+  candidates within a claim's clearance radius - bounded by how many NPCs are concurrently
+  camping/retreating/advancing, not total NPC count.
+- TTL is derived per-call from the calling operator's own duration blackboard key (`CampingTime`,
+  `AdvanceTime`, or the retreat-specific `RetreatClaimDuration`) plus a small safety buffer, so the
+  claim system itself stays behavior-agnostic.
+- Expired claims are swept in `Update()`; `TacticalPositionOperator`'s shutdown hooks release
+  claims immediately when a task ends normally, so the TTL sweep is only the safety net for
+  ungraceful termination (NPC deleted mid-task, plan aborted before shutdown hooks run).
+- Not thread-safe by design: every read/write happens from main-thread HTN callbacks
+  (`Plan`/`ConditionalShutdown`/`TaskShutdown`) or the system's own `Update` - never from
+  `PathfindingSystem`'s parallel path-processing.
+
+## Adding a new behavior that uses this system
+
+To wire a new HTN behavior onto the dynamic algorithm:
+
+1. Add a `!type:TacticalPositionOperator` task in the relevant `htnCompound`/`htnPrimitiveTask`
+   YAML, same as the existing camping/retreat/advance tasks.
+2. Set `referenceCoordinatesKey` to whatever blackboard coordinate the new behavior should search
+   around.
+3. Optionally set `markerProto` to an existing (or new) marker `utilityQuery` prototype if the
+   behavior should still prefer mapper-placed spots first.
+4. Tune `distanceCurve`/`losReferenceCoordinatesKey`/`fovReferenceCoordinatesKey`/
+   `randomProbability` to taste - these are the same considerations described above.
+5. Point a following `MoveToOperator`'s `targetKey` at the same `keyCoordinates` value.
+6. Give the operator a `claimDurationKey` pointing at a blackboard float that represents roughly
+   how long the NPC will occupy that spot, so the reservation table sizes itself sensibly.
+
+## Debugging
+
+Run the `ks_tacticalposdebug` console command (`[AdminCommand(AdminFlags.Debug)]`,
+`Content.Server/_KS14/NPC/Commands/TacticalPositionDebugCommand.cs`) to toggle a per-player debug
+overlay of the dynamic phase: every scored candidate (colored red-to-green by score), the chosen
+candidate (yellow outline), and live reservation-table claims (orange clearance-radius circles).
+
+This is deliberately lazy: `NpcTacticalPositionDebugSystem.AnyDebugging` gates whether
+`TacticalPositionOperator` does any of the extra work needed to report a debug frame (recording
+every candidate's coordinates/score, snapshotting the claim table via
+`NpcTacticalPositionClaimSystem.GetAllClaimsForDebug`). While nobody has the overlay toggled on,
+none of that bookkeeping happens - only the actual candidate scoring the NPCs need to function is
+ever computed. The command toggles a `HashSet<ICommonSession>` server-side
+(`NpcTacticalPositionDebugSystem`); frames are only broadcast to sessions in that set, and get
+pruned client-side after ~2 seconds of no update (`Content.Client/_KS14/NPC/TacticalPositionDebugSystem.cs`,
+`TacticalPositionDebugOverlay.cs`).

--- a/Klovn/Docs/npc_navmesh.md
+++ b/Klovn/Docs/npc_navmesh.md
@@ -136,12 +136,21 @@ Run the `ks_tacticalposdebug` console command (`[AdminCommand(AdminFlags.Debug)]
 overlay of the dynamic phase: every scored candidate (colored red-to-green by score), the chosen
 candidate (yellow outline), and live reservation-table claims (orange clearance-radius circles).
 
-This is deliberately lazy: `NpcTacticalPositionDebugSystem.AnyDebugging` gates whether
+Run it bare (`ks_tacticalposdebug`) to track every NPC using the query, or pass an entity ID
+(`ks_tacticalposdebug 1234`, tab-completable against entities with `HTNComponent`) to scope the
+overlay to just that one NPC. Running the command again with the same scope (no argument twice, or
+the same entity twice) turns it back off; passing a different entity switches the scope instead of
+disabling. The shell output always states the resulting scope ("tracking all entities" /
+"tracking <entity> only" / "disabled").
+
+This is deliberately lazy: `NpcTacticalPositionDebugSystem.IsTracking(owner)` gates whether
 `TacticalPositionOperator` does any of the extra work needed to report a debug frame (recording
 every candidate's coordinates/score, snapshotting the claim table via
-`NpcTacticalPositionClaimSystem.GetAllClaimsForDebug`). While nobody has the overlay toggled on,
-none of that bookkeeping happens - only the actual candidate scoring the NPCs need to function is
-ever computed. The command toggles a `HashSet<ICommonSession>` server-side
-(`NpcTacticalPositionDebugSystem`); frames are only broadcast to sessions in that set, and get
-pruned client-side after ~2 seconds of no update (`Content.Client/_KS14/NPC/TacticalPositionDebugSystem.cs`,
-`TacticalPositionDebugOverlay.cs`).
+`NpcTacticalPositionClaimSystem.GetAllClaimsForDebug`) for that particular NPC. While nobody is
+tracking a given NPC - either because no one has the overlay toggled on at all, or because every
+subscriber is scoped to a *different* entity - none of that bookkeeping happens for it; only the
+actual candidate scoring the NPCs need to function is ever computed. The command tracks a
+`Dictionary<ICommonSession, EntityUid?>` server-side (`NpcTacticalPositionDebugSystem`, null value
+= tracking everything); frames are only broadcast to sessions whose scope matches the reporting
+NPC, and get pruned client-side after ~2 seconds of no update
+(`Content.Client/_KS14/NPC/TacticalPositionDebugSystem.cs`, `TacticalPositionDebugOverlay.cs`).

--- a/Resources/Locale/en-US/_KS14/npc/tactical-position-debug.ftl
+++ b/Resources/Locale/en-US/_KS14/npc/tactical-position-debug.ftl
@@ -1,0 +1,6 @@
+cmd-ks_tacticalposdebug-desc = Toggles the dynamic NPC tactical position debug overlay (candidate scores, chosen spot, live claims) for you.
+cmd-ks_tacticalposdebug-help = ks_tacticalposdebug
+
+cmd-ks_tacticalposdebug-no-session = This command must be run by a player.
+cmd-ks_tacticalposdebug-enabled = Tactical position debug overlay enabled.
+cmd-ks_tacticalposdebug-disabled = Tactical position debug overlay disabled.

--- a/Resources/Locale/en-US/_KS14/npc/tactical-position-debug.ftl
+++ b/Resources/Locale/en-US/_KS14/npc/tactical-position-debug.ftl
@@ -1,6 +1,9 @@
-cmd-ks_tacticalposdebug-desc = Toggles the dynamic NPC tactical position debug overlay (candidate scores, chosen spot, live claims) for you.
-cmd-ks_tacticalposdebug-help = ks_tacticalposdebug
+cmd-ks_tacticalposdebug-desc = Toggles the dynamic NPC tactical position debug overlay (candidate scores, chosen spot, live claims) for you, optionally scoped to a single entity.
+cmd-ks_tacticalposdebug-help = ks_tacticalposdebug [entity]
 
 cmd-ks_tacticalposdebug-no-session = This command must be run by a player.
-cmd-ks_tacticalposdebug-enabled = Tactical position debug overlay enabled.
+cmd-ks_tacticalposdebug-invalid-entity = No entity found matching '{$entity}'.
+cmd-ks_tacticalposdebug-entity-hint = entity (optional, tracks all if omitted)
+cmd-ks_tacticalposdebug-enabled-all = Tactical position debug overlay enabled, tracking all entities.
+cmd-ks_tacticalposdebug-enabled-single = Tactical position debug overlay enabled, tracking { $entity } only.
 cmd-ks_tacticalposdebug-disabled = Tactical position debug overlay disabled.


### PR DESCRIPTION
## What was changed
camping markers are no longer required for NPCs, instead they build a navmesh and use that GEG
however, if camping markers are present, NPCs will prioritise those because WE TRUST MAPPERS TO PUT THEM IN GOOD PLACES OR SOMETHING

## Test plan
first remove all camping markers from devmap with `entities with NpcCampingSpot delete` in console
then spawn npcs and some obstacles like shown below and test
through debug overl

## Media
tba

## Requirements
- [x] Tested, works.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: The Operative AI has been improved.