### PR TITLE
add gas reaction for ammonia

### DIFF
--- a/Content.Server/Atmos/Reactions/AmmoniaOxygenReaction.cs
+++ b/Content.Server/Atmos/Reactions/AmmoniaOxygenReaction.cs
@@ -14,20 +14,52 @@ public sealed partial class AmmoniaOxygenReaction : IGasReactionEffect
         var nOxygen = mixture.GetMoles(Gas.Oxygen);
         var nTotal = mixture.TotalMoles;
 
-        // Concentration-dependent reaction rate
-        var fAmmonia = nAmmonia/nTotal;
-        var fOxygen = nOxygen/nTotal;
-        var rate = MathF.Pow(fAmmonia, 2) * MathF.Pow(fOxygen, 2);
-
-        var deltaMoles = nAmmonia / Atmospherics.AmmoniaOxygenReactionRate * 2 * rate;
-
-        if (deltaMoles <= 0 || nAmmonia - deltaMoles < 0)
+        // KS14 start: bail out early on an empty/invalid mixture instead of dividing by zero below
+        if (nTotal <= 0f || nAmmonia <= 0f || nOxygen <= 0f)
             return ReactionResult.NoReaction;
+        // KS14 end
+
+        // Concentration-dependent reaction rate
+        var fAmmonia = nAmmonia / nTotal; // KS14: nAmmonia/nTotal -> nAmmonia / nTotal
+        var fOxygen = nOxygen / nTotal; // KS14: nOxygen/nTotal -> nOxygen / nTotal
+        var rate = MathF.Pow(fAmmonia, 2f) * MathF.Pow(fOxygen, 2f); // KS14: 2 -> 2f
+
+        if (rate <= 0f) // KS14: added, avoid a zero-mole reaction below
+            return ReactionResult.NoReaction;
+
+        var deltaMoles = Math.Min(nAmmonia, nOxygen) / Atmospherics.AmmoniaOxygenReactionRate * 2f * rate; // KS14: nAmmonia -> Math.Min(nAmmonia, nOxygen), limit by whichever reagent runs out first
+
+        if (deltaMoles <= 0f) // KS14: dropped the redundant nAmmonia - deltaMoles < 0 check, Math.Min above already bounds deltaMoles
+            return ReactionResult.NoReaction;
+
+        // KS14 start: release reaction heat and expose a hotspot, matching other exothermic gas reactions
+        var energyReleased = 193000f * deltaMoles;
+        var oldHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
+        var temperature = mixture.Temperature;
+        var location = holder as TileAtmosphere;
+        // KS14 end
 
         mixture.AdjustMoles(Gas.Ammonia, -deltaMoles);
         mixture.AdjustMoles(Gas.Oxygen, -deltaMoles);
-        mixture.AdjustMoles(Gas.NitrousOxide, deltaMoles / 2);
+        mixture.AdjustMoles(Gas.NitrousOxide, deltaMoles / 2f); // KS14: 2 -> 2f
         mixture.AdjustMoles(Gas.WaterVapor, deltaMoles * 1.5f);
+
+        // KS14 start: apply reaction heat and expose a hotspot, matching other exothermic gas reactions
+        energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise
+        if (energyReleased > 0f)
+        {
+            var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
+            if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)
+                mixture.Temperature = (temperature * oldHeatCapacity + energyReleased) / newHeatCapacity;
+        }
+
+        if (location != null)
+        {
+            var mixTemperature = mixture.Temperature;
+            if (mixTemperature > 0f)
+                atmosphereSystem.HotspotExpose(location, mixTemperature, mixture.Volume);
+        }
+        // KS14 end
 
         return ReactionResult.Reacting;
     }

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -91,6 +91,7 @@
   color: '#56941E'
   reagent: Ammonia
   pricePerMole: 0.15
+  isFuel: true # KS14
 
 - type: gas
   id: NitrousOxide


### PR DESCRIPTION
## What was changed
<!-- If changelog sufficiently describes your changes, you may omit this section -->

## Why

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media

## Requirements
- [ ] Tested, works.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] Design doc

## Breaking changes
<!-- List any changes that might break future work -->

**Changelog**
:cl: some obsessed discord user
- tweak: Ammonia + oxygen reactions now release heat and can ignite hotspots, instead of just quietly converting into nitrous oxide and water vapor. Ammonia is also now treated as a fuel.